### PR TITLE
docs: add global API key setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,45 @@ Get your API key from the [Supermodel Dashboard](https://dashboard.supermodeltoo
 | `SUPERMODEL_API_KEY` | Your Supermodel API key (required) |
 | `SUPERMODEL_BASE_URL` | Override API base URL (optional) |
 
+### Global Setup (Recommended)
+
+Instead of adding your API key to each MCP config file, you can set it globally in your shell profile. This keeps your key in one place and automatically makes it available to all MCP clients.
+
+**For Zsh (macOS default):**
+
+Add to `~/.zshrc`:
+
+```bash
+export SUPERMODEL_API_KEY="your-api-key"
+```
+
+**For Bash:**
+
+Add to `~/.bashrc` or `~/.bash_profile`:
+
+```bash
+export SUPERMODEL_API_KEY="your-api-key"
+```
+
+Then reload your shell:
+
+```bash
+source ~/.zshrc  # or ~/.bashrc
+```
+
+With the API key set globally, you can omit the `env` block from your MCP configs:
+
+```json
+{
+  "mcpServers": {
+    "supermodel": {
+      "command": "npx",
+      "args": ["-y", "@supermodeltools/mcp-server"]
+    }
+  }
+}
+```
+
 ## Usage
 
 ### Cursor


### PR DESCRIPTION
Add a "Global Setup (Recommended)" section to the README explaining how to set SUPERMODEL_API_KEY in shell profile (~/.zshrc or ~/.bashrc) so users don't need to repeat the key in each MCP config file.

Closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a global setup guide for configuring SUPERMODEL_API_KEY in shell profiles (Zsh and Bash), with instructions for reloading your shell environment and simplifying MCP configuration files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->