### PR TITLE
Remove user-facing Idempotency-Key parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,22 +150,10 @@ Analyzes code structure, dependencies, and relationships across a repository. Us
 |----------|------|----------|-------------|
 | `directory` | string | Yes* | Path to repository directory (automatic zipping) |
 | `file` | string | Yes* | Path to pre-zipped archive (deprecated) |
-| `Idempotency-Key` | string | Yes | Cache key in format `{repo}:{type}:{hash}` |
 | `query` | string | No | Query type (summary, search, list_nodes, etc.) |
 | `jq_filter` | string | No | jq filter for custom data extraction |
 
 \* Either `directory` (recommended) or `file` must be provided
-
-**Quick start:**
-
-```bash
-# 1. Get commit hash for cache key
-git rev-parse --short HEAD
-# Output: abc123
-
-# 2. Ask Claude to analyze (no manual zipping needed!)
-# "Analyze the codebase at /path/to/repo using key myproject:supermodel:abc123"
-```
 
 **Example prompts:**
 - "Analyze the codebase at . to understand its architecture"


### PR DESCRIPTION
## Summary
- Removed the user-facing `Idempotency-Key` parameter from the tool schema and documentation
- The API no longer caches responses based on the idempotency key, so users don't need to provide or manage it
- Idempotency key is still generated internally and sent to the API for request deduplication

## Changes
- Removed `Idempotency-Key` from tool input schema
- Removed documentation about cache keys and quick start instructions
- Simplified handler to always auto-generate idempotency key internally
- Removed response metadata about auto-generated keys
- Kept internal idempotency key generation and API request parameter

## Test plan
- [ ] Verify tool can be called without Idempotency-Key parameter
- [ ] Verify API requests still include auto-generated idempotency key
- [ ] Verify local caching still works correctly
- [ ] Verify documentation no longer references user-provided cache keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Quick start guide updated and simplified by removing manual cache-key configuration procedures and zipping steps.

* **Refactor**
  * Idempotency-Key parameter removed from the API. Key generation is now automatic and requires no user configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->