### PR TITLE
Fix #17 #20: Use fs.lstat() to prevent symlink traversal security vulnerability

### DIFF
--- a/src/utils/zip-repository.ts
+++ b/src/utils/zip-repository.ts
@@ -310,13 +310,19 @@ async function addFilesRecursively(
 
     let stats;
     try {
-      stats = await fs.stat(fullPath);
+      stats = await fs.lstat(fullPath);
     } catch (error: any) {
       if (error.code === 'ENOENT') {
-        // Symlink pointing to non-existent file, skip
+        // File disappeared, skip
         continue;
       }
       console.error('[WARN] Failed to stat:', fullPath, error.message);
+      continue;
+    }
+
+    // Skip symlinks to prevent following links outside the repository
+    if (stats.isSymbolicLink()) {
+      console.error('[WARN] Skipping symlink:', fullPath);
       continue;
     }
 
@@ -337,7 +343,7 @@ async function addFilesRecursively(
         console.error('[WARN] Failed to add file:', fullPath, error.message);
       }
     }
-    // Skip symlinks, sockets, etc.
+    // Skip other special files (sockets, FIFOs, etc.)
   }
 }
 


### PR DESCRIPTION
## Summary
Fixes #17 and #20 - Security fix to prevent symlink traversal vulnerability

## Problem
The code used `fs.stat()` which follows symlinks. This created a **security vulnerability** where malicious symlinks could cause sensitive files from outside the repository to be included in ZIP archives:
- `config -> /etc/passwd`
- `keys -> ~/.ssh/id_rsa`
- `secrets -> /home/user/private/`

## Solution
Changed to `fs.lstat()` which does NOT follow symlinks, and added explicit detection to skip them:

```typescript
stats = await fs.lstat(fullPath);

// Skip symlinks to prevent following links outside the repository
if (stats.isSymbolicLink()) {
  console.error('[WARN] Skipping symlink:', fullPath);
  continue;
}
```

## Changes
- Updated `src/utils/zip-repository.ts`:
  - Line 313: Changed `fs.stat()` to `fs.lstat()`
  - Added symlink detection: `stats.isSymbolicLink()`
  - Added skip logic with warning message
  - Updated related comments for clarity

## Security Review
Reviewed all other `fs.stat()` calls in the file:
- Line 118: Directory validation - Safe (intentional symlink following for root)
- Line 212: ZIP file size check - Safe (checking our own created file)
- Line 381: Cleanup function - Safe (checking our own created files)

Only line 313 needed the security fix.

## Testing
- ✅ Build passes: `npm run build`
- ✅ Symlinks are now skipped with warning
- ✅ Regular files still processed correctly
- ✅ No sensitive file leakage possible

## Impact
**HIGH PRIORITY SECURITY FIX**
- Eliminates potential for sensitive file leakage
- Symlinks are now safely skipped instead of followed
- Maintains expected behavior for normal files

Closes #17
Closes #20