### PR TITLE
feat: Add optional default working directory support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,34 @@ With the API key set globally, you can omit the `env` block from your MCP config
 }
 ```
 
+### Default Working Directory (Optional)
+
+For automated benchmarking tools (like mcpbr) or batch processing, you can specify a default working directory as a command-line argument. When provided, the `explore_codebase` tool will use this directory automatically if no explicit `directory` parameter is given.
+
+**Command-line usage:**
+
+```bash
+npx @supermodeltools/mcp-server /path/to/repository
+```
+
+or with Node.js:
+
+```bash
+node dist/index.js /path/to/repository
+```
+
+**Example with benchmarking tools:**
+
+```yaml
+mcp_server:
+  command: "npx"
+  args: ["-y", "@supermodeltools/mcp-server", "{workdir}"]
+  env:
+    SUPERMODEL_API_KEY: "${SUPERMODEL_API_KEY}"
+```
+
+This allows the agent to call `explore_codebase()` without specifying a directory parameter, automatically using the configured default workdir. You can still override it by explicitly passing a `directory` parameter in individual tool calls.
+
 ## Usage
 
 ### Cursor

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,16 @@ import { Server } from './server';
 import * as logger from './utils/logger';
 
 async function main() {
-  const server = new Server();
+  // Parse command-line arguments to get optional default workdir
+  // Usage: node dist/index.js [workdir]
+  const args = process.argv.slice(2);
+  const defaultWorkdir = args.length > 0 ? args[0] : undefined;
+
+  if (defaultWorkdir) {
+    logger.debug('Default workdir:', defaultWorkdir);
+  }
+
+  const server = new Server(defaultWorkdir);
   await server.start();
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -35,8 +35,10 @@ const fetchWithTimeout: typeof fetch = (url, init) => {
 export class Server {
   private server: McpServer;
   private client: ClientContext;
+  private defaultWorkdir?: string;
 
-  constructor() {
+  constructor(defaultWorkdir?: string) {
+    this.defaultWorkdir = defaultWorkdir;
     this.server = new McpServer(
       {
         name: 'supermodel_api',
@@ -90,6 +92,9 @@ Example:
     logger.debug('Server configuration:');
     logger.debug('Base URL:', config.basePath);
     logger.debug('API Key set:', !!process.env.SUPERMODEL_API_KEY);
+    if (this.defaultWorkdir) {
+      logger.debug('Default workdir:', this.defaultWorkdir);
+    }
 
     this.client = {
       graphs: new DefaultApi(config),
@@ -109,7 +114,7 @@ Example:
       const { name, arguments: args } = request.params;
       
       if (name === createSupermodelGraphTool.tool.name) {
-        return createSupermodelGraphTool.handler(this.client, args);
+        return createSupermodelGraphTool.handler(this.client, args, this.defaultWorkdir);
       }
       
       throw new Error(`Unknown tool: ${name}`);

--- a/src/tools/create-supermodel-graph.test.ts
+++ b/src/tools/create-supermodel-graph.test.ts
@@ -70,19 +70,19 @@ describe('create-supermodel-graph', () => {
       } as any;
     });
 
-    it('should return error when no arguments provided', async () => {
+    it('should return error when no arguments provided and no default workdir', async () => {
       const result = await handler(mockClient, undefined);
 
       expect(result.content).toEqual([
         {
           type: 'text',
-          text: expect.stringContaining('Missing required arguments'),
+          text: expect.stringContaining('No "directory" parameter provided and no default workdir configured'),
         },
       ]);
       expect(result.isError).toBe(true);
     });
 
-    it('should return error when directory is missing', async () => {
+    it('should return error when directory is missing and no default workdir', async () => {
       const args = {
         query: 'summary',
       };
@@ -92,7 +92,7 @@ describe('create-supermodel-graph', () => {
       expect(result.content).toEqual([
         {
           type: 'text',
-          text: expect.stringContaining('Invalid "directory" parameter'),
+          text: expect.stringContaining('No "directory" parameter provided and no default workdir configured'),
         },
       ]);
       expect(result.isError).toBe(true);
@@ -113,6 +113,24 @@ describe('create-supermodel-graph', () => {
         },
       ]);
       expect(result.isError).toBe(true);
+    });
+
+    it('should use default workdir when directory is not provided', async () => {
+      const args = {
+        query: 'summary',
+      };
+      const defaultWorkdir = '/default/workdir';
+
+      const result = await handler(mockClient, args, defaultWorkdir);
+
+      // Should not error with validation message since defaultWorkdir is provided
+      // The actual behavior depends on whether the directory exists
+      // but the validation should pass
+      expect(result.isError).toBe(true); // Will error on actual zip creation, not validation
+      const content = result.content[0];
+      if (content.type === 'text') {
+        expect(content.text).not.toContain('No "directory" parameter provided');
+      }
     });
   });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,8 @@ export type ToolCallResult = {
 
 export type HandlerFunction = (
   client: ClientContext,
-  args: Record<string, unknown> | undefined
+  args: Record<string, unknown> | undefined,
+  defaultWorkdir?: string
 ) => Promise<ToolCallResult>;
 
 export type Metadata = {


### PR DESCRIPTION
## Problem

Automated benchmarking tools like [mcpbr](https://github.com/greynewell/mcpbr) expect MCP servers to accept a working directory as a command-line argument (similar to `@modelcontextprotocol/server-filesystem`). Currently, Supermodel MCP doesn't support this pattern, requiring the `directory` parameter to be explicitly provided in every `explore_codebase` tool call.

This incompatibility prevents proper integration with benchmarking frameworks that need to automatically inject the repository path when spawning MCP server processes.

## Solution

Add optional default working directory support via command-line argument:

```bash
npx @supermodeltools/mcp-server /path/to/repository
```

When configured, the `explore_codebase` tool uses this default directory automatically if no explicit `directory` parameter is provided. Explicit directory parameters still work and take precedence.

## Changes

- 📝 Make `directory` parameter optional in `explore_codebase` tool schema
- ⚙️ Accept optional workdir as command-line argument
- 🔄 Add fallback logic: `providedDirectory || defaultWorkdir`
- ✅ Update tests and add coverage for new behavior
- 📚 Document usage in README

## Example Usage

### With mcpbr

```yaml
mcp_server:
  command: "npx"
  args: ["-y", "@supermodeltools/mcp-server", "{workdir}"]
  env:
    SUPERMODEL_API_KEY: "${SUPERMODEL_API_KEY}"
```

### Direct usage

```bash
# With default workdir
node dist/index.js /path/to/repo

# Agent can now call without directory parameter
explore_codebase(query="summary")  # Uses /path/to/repo

# Or override with explicit directory
explore_codebase(directory="/other/path", query="summary")
```

## Testing

- ✅ All existing tests pass
- ✅ Added test for default workdir behavior
- ✅ TypeScript compilation successful
- ✅ Backward compatible - existing usage unaffected

## Benefits

1. **Benchmarking Integration**: Works seamlessly with mcpbr and similar tools
2. **Reduced Verbosity**: Agents don't need to repeat directory path
3. **Flexibility**: Explicit directory still works, no breaking changes
4. **Clear Error Messages**: Helpful validation messages guide users

Closes #XX (if there's an issue tracking this)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for specifying a default working directory as a command-line argument, enabling streamlined automated benchmarking and batch processing workflows.
  * Default directory is automatically used when no explicit directory is provided and can be overridden per call.
  * Includes updated documentation with usage examples and configuration guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->