### PR TITLE
Add timeout configuration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,73 +55,7 @@ echo $MCP_TOOL_TIMEOUT
 
 </details>
 
-<details>
-<summary><strong>Claude Desktop (macOS)</strong></summary>
-
-Edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
-
-```json
-{
-  "mcpServers": {
-    "supermodel": {
-      "command": "npx",
-      "args": ["-y", "@supermodeltools/mcp-server"],
-      "env": {
-        "SUPERMODEL_API_KEY": "your-api-key",
-        "MCP_TOOL_TIMEOUT": "900000"
-      }
-    }
-  }
-}
-```
-
-</details>
-
-<details>
-<summary><strong>Claude Desktop (Linux)</strong></summary>
-
-Edit `~/.config/Claude/claude_desktop_config.json`:
-
-```json
-{
-  "mcpServers": {
-    "supermodel": {
-      "command": "npx",
-      "args": ["-y", "@supermodeltools/mcp-server"],
-      "env": {
-        "SUPERMODEL_API_KEY": "your-api-key",
-        "MCP_TOOL_TIMEOUT": "900000"
-      }
-    }
-  }
-}
-```
-
-</details>
-
-<details>
-<summary><strong>Claude Desktop (Windows)</strong></summary>
-
-Edit `%APPDATA%\Claude\claude_desktop_config.json`:
-
-```json
-{
-  "mcpServers": {
-    "supermodel": {
-      "command": "npx",
-      "args": ["-y", "@supermodeltools/mcp-server"],
-      "env": {
-        "SUPERMODEL_API_KEY": "your-api-key",
-        "MCP_TOOL_TIMEOUT": "900000"
-      }
-    }
-  }
-}
-```
-
-</details>
-
-For more details on timeout configuration, see the [official Claude Code documentation](https://code.claude.com/docs/en/settings.md).
+**Note:** Timeout configuration via `MCP_TOOL_TIMEOUT` is only supported in Claude Code CLI. For more details, see the [official Claude Code documentation](https://code.claude.com/docs/en/settings.md).
 
 ## Configuration
 
@@ -219,25 +153,7 @@ Add to `~/.cursor/mcp.json`:
 }
 ```
 
-### Claude Desktop
-
-Add to `claude_desktop_config.json`:
-
-```json
-{
-  "mcpServers": {
-    "supermodel": {
-      "command": "npx",
-      "args": ["-y", "@supermodeltools/mcp-server"],
-      "env": {
-        "SUPERMODEL_API_KEY": "your-api-key"
-      }
-    }
-  }
-}
-```
-
-### Claude Code
+### Claude Code CLI
 
 Add the MCP server with your API key:
 


### PR DESCRIPTION
Closes #59

Adds comprehensive timeout configuration documentation to help users avoid the default 60-120s timeout when using explore_codebase on large repositories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an “Important: Configure Timeout for Large Codebase Analysis” section with a recommended 15-minute timeout, verification steps, and guidance to prevent interruptions during long analyses.
  * Replaced the previous desktop configuration guidance with focused instructions for the Claude Code CLI, including how to register the MCP server and verify the CLI installation.  
  * Note: timeout configuration is supported only in the Claude Code CLI.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->