### PR TITLE
Add execution time warning to tool description

### DIFF
--- a/src/tools/create-supermodel-graph.ts
+++ b/src/tools/create-supermodel-graph.ts
@@ -28,7 +28,9 @@ export const metadata: Metadata = {
 
 export const tool: Tool = {
   name: 'explore_codebase',
-  description: `Analyzes code within the target directory to produce a graph that can be used to navigate the codebase when solving bugs, planning or analyzing code changes.
+  description: `Comprehensive codebase analysis using Supermodel API. ⚠️ This operation takes 5-15 minutes for large repositories. Ensure your Claude CLI timeout is configured (MCP_TOOL_TIMEOUT=900000). Analyzes code structure, dependencies, and patterns while respecting .gitignore.
+
+Analyzes code within the target directory to produce a graph that can be used to navigate the codebase when solving bugs, planning or analyzing code changes.
 
 ## Example Output
 


### PR DESCRIPTION
Closes #60

Updates explore_codebase tool description to warn users about the 5-15 minute execution time and required timeout configuration.

## Changes
- Added warning emoji (⚠️) and execution time estimate
- Added timeout configuration reminder (MCP_TOOL_TIMEOUT=900000)
- Clarified that the tool respects .gitignore

## Example
The new description now starts with:
> Comprehensive codebase analysis using Supermodel API. ⚠️ This operation takes 5-15 minutes for large repositories. Ensure your Claude CLI timeout is configured (MCP_TOOL_TIMEOUT=900000). Analyzes code structure, dependencies, and patterns while respecting .gitignore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded tool description to include a warning about extended runtime and guidance for configuring CLI timeout settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->