### PR TITLE
Add setup.sh script for easy timeout configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,32 @@ Run the setup script to configure the recommended timeout settings:
 curl -sSL https://raw.githubusercontent.com/supermodeltools/mcp/main/setup.sh | bash
 ```
 
-Or clone the repo and run locally:
+<details>
+<summary>Prefer to inspect before running? (Click to expand)</summary>
+
+Download, review, then execute:
+
+```bash
+# Download the script
+curl -sSL https://raw.githubusercontent.com/supermodeltools/mcp/main/setup.sh -o setup.sh
+
+# Review the contents
+cat setup.sh
+
+# Make executable and run
+chmod +x setup.sh
+./setup.sh
+```
+
+Or clone the entire repo:
 
 ```bash
 git clone https://github.com/supermodeltools/mcp.git
 cd mcp
 ./setup.sh
 ```
+
+</details>
 
 This will configure `MCP_TOOL_TIMEOUT=900000` for optimal performance with large codebases.
 

--- a/setup.sh
+++ b/setup.sh
@@ -13,9 +13,9 @@ echo "Supermodel MCP Server Setup"
 echo "============================"
 echo ""
 
-# Set timeout for current shell session
+# Set timeout for this script process (won't affect your terminal)
 export MCP_TOOL_TIMEOUT=${TIMEOUT_VALUE}
-echo "✓ Set MCP_TOOL_TIMEOUT=${TIMEOUT_VALUE} for current session"
+echo "✓ Will set MCP_TOOL_TIMEOUT=${TIMEOUT_VALUE} (reload shell to apply)"
 
 # Detect user's shell
 SHELL_NAME=$(basename "$SHELL")
@@ -24,10 +24,16 @@ PROFILE_FILE=""
 if [ "$SHELL_NAME" = "zsh" ]; then
     PROFILE_FILE="$HOME/.zshrc"
 elif [ "$SHELL_NAME" = "bash" ]; then
-    if [ -f "$HOME/.bashrc" ]; then
-        PROFILE_FILE="$HOME/.bashrc"
-    elif [ -f "$HOME/.bash_profile" ]; then
+    # For bash, prefer .bash_profile for login shells (macOS/Linux)
+    # If .bash_profile exists but doesn't source .bashrc, warn the user
+    if [ -f "$HOME/.bash_profile" ]; then
         PROFILE_FILE="$HOME/.bash_profile"
+        if [ -f "$HOME/.bashrc" ] && ! grep -q "\.bashrc" "$HOME/.bash_profile"; then
+            echo "⚠ Note: Your .bash_profile doesn't source .bashrc"
+            echo "   Consider adding: source ~/.bashrc"
+        fi
+    elif [ -f "$HOME/.bashrc" ]; then
+        PROFILE_FILE="$HOME/.bashrc"
     else
         PROFILE_FILE="$HOME/.bashrc"
     fi


### PR DESCRIPTION
Closes #64

Adds a convenience script that configures MCP_TOOL_TIMEOUT environment variable and persists it to the user's shell profile for a smoother setup experience.

## Changes

- Created `setup.sh` script that:
  - Sets `MCP_TOOL_TIMEOUT=900000` in the current shell session
  - Detects the user's shell (bash or zsh)
  - Adds the export to the appropriate profile file (~/.bashrc or ~/.zshrc) if not already present
  - Provides clear output with checkmarks and next steps
  - Shows instructions for installing the MCP server and configuring the API key

- Updated README.md with:
  - Quick Setup section recommending the setup script
  - Instructions for running the script via curl or locally
  - Preserved existing manual installation instructions

## Benefits

- Streamlined onboarding experience
- Automatic timeout configuration for optimal performance with large codebases
- Shell-aware configuration (detects bash vs zsh)
- Clear next steps for users after running the script

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated setup script to streamline initial installation and environment configuration.

* **Documentation**
  * Added a Quick Setup section with one-line install instructions and local setup flow.
  * Documented setting and persisting MCP_TOOL_TIMEOUT for better performance on large codebases.
  * Added brief guidance for reloading shell profiles and configuring API keys and server linkage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->