### PR TITLE
feat: Add get_related tool and anti-chasing guidance

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,3 +25,9 @@ export const MAX_SYMBOL_CALLERS = 10; // Top N callers to show
 export const MAX_SYMBOL_CALLEES = 10; // Top N callees to show
 export const MAX_SYMBOL_RELATED = 8; // Related symbols in same file
 export const MAX_SOURCE_LINES = 50; // Max lines of source code to include inline
+
+// get_related tool limits
+export const MAX_RELATED_TARGETS = 5; // Max number of targets in a get_related query
+export const MAX_RELATED_DEPTH = 3; // Max BFS depth for connecting paths
+export const DEFAULT_RELATED_DEPTH = 2; // Default BFS depth
+export const MAX_BRIDGE_SOURCE_LINES = 30; // Max source lines for bridge node snippets

--- a/src/server.integration.test.ts
+++ b/src/server.integration.test.ts
@@ -135,20 +135,21 @@ describe('MCP Server Integration', () => {
   });
 
   describe('tools/list', () => {
-    it('should list exactly 2 tools', async () => {
+    it('should list exactly 3 tools', async () => {
       const result = await sendRequest('tools/list', {});
 
       expect(result.tools).toBeDefined();
       expect(Array.isArray(result.tools)).toBe(true);
-      expect(result.tools.length).toBe(2);
+      expect(result.tools.length).toBe(3);
     });
 
-    it('should include overview and symbol_context tools', async () => {
+    it('should include overview, symbol_context, and get_related tools', async () => {
       const result = await sendRequest('tools/list', {});
       const toolNames = result.tools.map((t: any) => t.name);
 
       expect(toolNames).toContain('overview');
       expect(toolNames).toContain('symbol_context');
+      expect(toolNames).toContain('get_related');
     });
 
     it('should have correct schema for tools', async () => {

--- a/src/tools/get-related.test.ts
+++ b/src/tools/get-related.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from '@jest/globals';
+import { buildIndexes } from '../cache/graph-cache';
+import { findShortestPath } from './get-related';
+
+// ── Helpers ──
+
+function buildGraph(
+  nodes: Array<{ id: string; labels: string[]; properties: Record<string, unknown> }>,
+  relationships: Array<{ id: string; type: string; startNode: string; endNode: string; properties?: Record<string, unknown> }> = [],
+) {
+  const raw: any = {
+    repo: 'test-repo',
+    graph: { nodes, relationships: relationships.map(r => ({ ...r, properties: r.properties ?? {} })) },
+  };
+  return buildIndexes(raw, 'test-key');
+}
+
+// ── findShortestPath tests ──
+
+describe('findShortestPath', () => {
+  it('finds direct call between two functions', () => {
+    const graph = buildGraph(
+      [
+        { id: 'a', labels: ['Function'], properties: { name: 'funcA', filePath: 'a.py', startLine: 1 } },
+        { id: 'b', labels: ['Function'], properties: { name: 'funcB', filePath: 'b.py', startLine: 1 } },
+      ],
+      [
+        { id: 'r1', type: 'calls', startNode: 'a', endNode: 'b' },
+      ],
+    );
+
+    const sourceNodes = [graph.nodeById.get('a')!];
+    const targetNodes = [graph.nodeById.get('b')!];
+    const path = findShortestPath(graph, sourceNodes, targetNodes, 3);
+
+    expect(path).not.toBeNull();
+    expect(path!.length).toBe(2);
+    expect(path![0].id).toBe('a');
+    expect(path![1].id).toBe('b');
+  });
+
+  it('finds 2-hop path through intermediate function', () => {
+    const graph = buildGraph(
+      [
+        { id: 'a', labels: ['Function'], properties: { name: 'funcA', filePath: 'a.py', startLine: 1 } },
+        { id: 'bridge', labels: ['Function'], properties: { name: 'bridge', filePath: 'b.py', startLine: 1 } },
+        { id: 'c', labels: ['Function'], properties: { name: 'funcC', filePath: 'c.py', startLine: 1 } },
+      ],
+      [
+        { id: 'r1', type: 'calls', startNode: 'a', endNode: 'bridge' },
+        { id: 'r2', type: 'calls', startNode: 'bridge', endNode: 'c' },
+      ],
+    );
+
+    const path = findShortestPath(
+      graph,
+      [graph.nodeById.get('a')!],
+      [graph.nodeById.get('c')!],
+      3,
+    );
+
+    expect(path).not.toBeNull();
+    expect(path!.length).toBe(3);
+    expect(path![0].id).toBe('a');
+    expect(path![1].id).toBe('bridge');
+    expect(path![2].id).toBe('c');
+  });
+
+  it('returns null when no path exists within max_depth', () => {
+    const graph = buildGraph(
+      [
+        { id: 'a', labels: ['Function'], properties: { name: 'funcA', filePath: 'a.py', startLine: 1 } },
+        { id: 'b', labels: ['Function'], properties: { name: 'funcB', filePath: 'b.py', startLine: 1 } },
+        { id: 'c', labels: ['Function'], properties: { name: 'funcC', filePath: 'c.py', startLine: 1 } },
+        { id: 'd', labels: ['Function'], properties: { name: 'funcD', filePath: 'd.py', startLine: 1 } },
+      ],
+      [
+        { id: 'r1', type: 'calls', startNode: 'a', endNode: 'b' },
+        { id: 'r2', type: 'calls', startNode: 'b', endNode: 'c' },
+        { id: 'r3', type: 'calls', startNode: 'c', endNode: 'd' },
+      ],
+    );
+
+    // depth 2 can't reach 3-hop path
+    const path = findShortestPath(
+      graph,
+      [graph.nodeById.get('a')!],
+      [graph.nodeById.get('d')!],
+      2,
+    );
+
+    expect(path).toBeNull();
+  });
+
+  it('returns null when targets are completely disconnected', () => {
+    const graph = buildGraph([
+      { id: 'a', labels: ['Function'], properties: { name: 'funcA', filePath: 'a.py', startLine: 1 } },
+      { id: 'b', labels: ['Function'], properties: { name: 'funcB', filePath: 'b.py', startLine: 1 } },
+    ]);
+
+    const path = findShortestPath(
+      graph,
+      [graph.nodeById.get('a')!],
+      [graph.nodeById.get('b')!],
+      3,
+    );
+
+    expect(path).toBeNull();
+  });
+
+  it('finds path through reverse call edges (callee → caller)', () => {
+    const graph = buildGraph(
+      [
+        { id: 'a', labels: ['Function'], properties: { name: 'funcA', filePath: 'a.py', startLine: 1 } },
+        { id: 'b', labels: ['Function'], properties: { name: 'funcB', filePath: 'b.py', startLine: 1 } },
+      ],
+      [
+        // b calls a — but we search from a to b, which should follow the in-edge
+        { id: 'r1', type: 'calls', startNode: 'b', endNode: 'a' },
+      ],
+    );
+
+    const path = findShortestPath(
+      graph,
+      [graph.nodeById.get('a')!],
+      [graph.nodeById.get('b')!],
+      3,
+    );
+
+    expect(path).not.toBeNull();
+    expect(path!.length).toBe(2);
+  });
+
+  it('finds path through import edges', () => {
+    const graph = buildGraph(
+      [
+        { id: 'f1', labels: ['File'], properties: { name: 'module_a', filePath: 'a.py' } },
+        { id: 'f2', labels: ['File'], properties: { name: 'module_b', filePath: 'b.py' } },
+      ],
+      [
+        { id: 'r1', type: 'IMPORTS', startNode: 'f1', endNode: 'f2' },
+      ],
+    );
+
+    const path = findShortestPath(
+      graph,
+      [graph.nodeById.get('f1')!],
+      [graph.nodeById.get('f2')!],
+      3,
+    );
+
+    expect(path).not.toBeNull();
+    expect(path!.length).toBe(2);
+  });
+
+  it('returns single node when source and target overlap', () => {
+    const graph = buildGraph([
+      { id: 'a', labels: ['Function'], properties: { name: 'funcA', filePath: 'a.py', startLine: 1 } },
+    ]);
+
+    const node = graph.nodeById.get('a')!;
+    const path = findShortestPath(graph, [node], [node], 3);
+
+    expect(path).not.toBeNull();
+    expect(path!.length).toBe(1);
+    expect(path![0].id).toBe('a');
+  });
+
+  it('picks shortest of multiple possible paths', () => {
+    // a → bridge1 → c (2 hops)
+    // a → x → y → c (3 hops)
+    const graph = buildGraph(
+      [
+        { id: 'a', labels: ['Function'], properties: { name: 'a', filePath: 'a.py', startLine: 1 } },
+        { id: 'bridge1', labels: ['Function'], properties: { name: 'bridge1', filePath: 'b.py', startLine: 1 } },
+        { id: 'x', labels: ['Function'], properties: { name: 'x', filePath: 'x.py', startLine: 1 } },
+        { id: 'y', labels: ['Function'], properties: { name: 'y', filePath: 'y.py', startLine: 1 } },
+        { id: 'c', labels: ['Function'], properties: { name: 'c', filePath: 'c.py', startLine: 1 } },
+      ],
+      [
+        { id: 'r1', type: 'calls', startNode: 'a', endNode: 'bridge1' },
+        { id: 'r2', type: 'calls', startNode: 'bridge1', endNode: 'c' },
+        { id: 'r3', type: 'calls', startNode: 'a', endNode: 'x' },
+        { id: 'r4', type: 'calls', startNode: 'x', endNode: 'y' },
+        { id: 'r5', type: 'calls', startNode: 'y', endNode: 'c' },
+      ],
+    );
+
+    const path = findShortestPath(
+      graph,
+      [graph.nodeById.get('a')!],
+      [graph.nodeById.get('c')!],
+      3,
+    );
+
+    expect(path).not.toBeNull();
+    // BFS guarantees shortest path
+    expect(path!.length).toBe(3); // a → bridge1 → c
+  });
+});

--- a/src/tools/get-related.ts
+++ b/src/tools/get-related.ts
@@ -1,0 +1,418 @@
+/**
+ * `get_related` tool -- connecting subgraph between known symbols.
+ *
+ * Given 2-5 symbol names or file paths, BFS-traverses the call and import
+ * graphs to find shortest connecting paths. Returns the subgraph as markdown
+ * with source snippets for bridge nodes.
+ *
+ * Replaces the "symbol chasing" anti-pattern where agents make 5-7 sequential
+ * symbol_context calls to manually trace a call chain.
+ */
+
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import { Tool } from '@modelcontextprotocol/sdk/types.js';
+import {
+  Endpoint,
+  HandlerFunction,
+  asTextContentResult,
+  asErrorResult,
+} from '../types';
+import {
+  IndexedGraph,
+  resolveOrFetchGraph,
+  normalizePath,
+} from '../cache/graph-cache';
+import { CodeGraphNode } from '../cache/graph-types';
+import { classifyApiError } from '../utils/api-helpers';
+import { findSymbol, languageFromExtension } from './symbol-context';
+import {
+  MAX_RELATED_TARGETS,
+  MAX_RELATED_DEPTH,
+  DEFAULT_RELATED_DEPTH,
+  MAX_BRIDGE_SOURCE_LINES,
+} from '../constants';
+
+export const tool: Tool = {
+  name: 'get_related',
+  description:
+    `Given 2-5 symbol names or file paths, returns the connecting call-graph paths between them in a single response. Replaces sequential symbol_context chains — instead of tracing A→B→C→D one call at a time, call get_related({targets: ["A", "D"]}) to get the full path instantly. Sub-second, zero cost. Use this when you know the start and end points (from a stack trace, error message, or issue description) and need to understand how they connect.`,
+  inputSchema: {
+    type: 'object',
+    properties: {
+      targets: {
+        type: 'array',
+        items: { type: 'string' },
+        minItems: 2,
+        maxItems: MAX_RELATED_TARGETS,
+        description:
+          'Symbol names (e.g. "QuerySet.filter") or file paths (e.g. "django/db/models/query.py") to connect. 2-5 targets.',
+      },
+      max_depth: {
+        type: 'number',
+        description:
+          `Maximum BFS depth for path finding (default ${DEFAULT_RELATED_DEPTH}, max ${MAX_RELATED_DEPTH}). Increase if targets are far apart in the call graph.`,
+      },
+      directory: {
+        type: 'string',
+        description:
+          'Path to the repository directory. Omit if the MCP server was started with a default workdir.',
+      },
+    },
+    required: ['targets'],
+  },
+};
+
+export const handler: HandlerFunction = async (client, args, defaultWorkdir) => {
+  const targets = args?.targets as string[] | undefined;
+  const rawDir = args?.directory as string | undefined;
+  const directory = (rawDir && rawDir.trim()) || defaultWorkdir || process.cwd();
+  const maxDepth = Math.min(
+    Math.max(1, Number(args?.max_depth) || DEFAULT_RELATED_DEPTH),
+    MAX_RELATED_DEPTH,
+  );
+
+  if (!targets || !Array.isArray(targets) || targets.length < 2) {
+    return asErrorResult({
+      type: 'validation_error',
+      message: 'Provide at least 2 targets (symbol names or file paths).',
+      code: 'INVALID_TARGETS',
+      recoverable: false,
+      suggestion: 'Example: get_related({targets: ["QuerySet.filter", "SQLCompiler.compile"]})',
+    });
+  }
+
+  if (targets.length > MAX_RELATED_TARGETS) {
+    return asErrorResult({
+      type: 'validation_error',
+      message: `Too many targets (max ${MAX_RELATED_TARGETS}).`,
+      code: 'TOO_MANY_TARGETS',
+      recoverable: false,
+      suggestion: `Provide at most ${MAX_RELATED_TARGETS} targets.`,
+    });
+  }
+
+  if (!directory || typeof directory !== 'string') {
+    return asErrorResult({
+      type: 'validation_error',
+      message: 'No directory provided and no default workdir configured.',
+      code: 'MISSING_DIRECTORY',
+      recoverable: false,
+      suggestion: 'Provide a directory parameter or start the MCP server with a workdir argument.',
+    });
+  }
+
+  let graph: IndexedGraph;
+  try {
+    graph = await resolveOrFetchGraph(client, directory);
+  } catch (error: any) {
+    return asErrorResult(classifyApiError(error));
+  }
+
+  // Resolve each target to node IDs
+  const resolvedTargets: Array<{ query: string; nodes: CodeGraphNode[] }> = [];
+  const unresolvedTargets: string[] = [];
+
+  for (const target of targets) {
+    const trimmed = target.trim();
+    if (!trimmed) continue;
+
+    const nodes = resolveTarget(graph, trimmed);
+    if (nodes.length > 0) {
+      resolvedTargets.push({ query: trimmed, nodes });
+    } else {
+      unresolvedTargets.push(trimmed);
+    }
+  }
+
+  if (resolvedTargets.length < 2) {
+    const resolvedNames = resolvedTargets.map(t => t.query);
+    return asTextContentResult(
+      `Could not resolve enough targets to find connections.\n\n` +
+      (resolvedNames.length > 0 ? `Resolved: ${resolvedNames.join(', ')}\n` : '') +
+      `Unresolved: ${unresolvedTargets.join(', ')}\n\n` +
+      `Try different symbol names or use \`symbol_context\` to verify they exist.`
+    );
+  }
+
+  // Find paths between all pairs of resolved targets
+  const allPaths: PathResult[] = [];
+  for (let i = 0; i < resolvedTargets.length; i++) {
+    for (let j = i + 1; j < resolvedTargets.length; j++) {
+      const pathResult = findShortestPath(
+        graph,
+        resolvedTargets[i].nodes,
+        resolvedTargets[j].nodes,
+        maxDepth,
+      );
+      if (pathResult) {
+        allPaths.push({
+          from: resolvedTargets[i].query,
+          to: resolvedTargets[j].query,
+          path: pathResult,
+        });
+      }
+    }
+  }
+
+  // Render output
+  const rendered = await renderRelated(
+    graph,
+    resolvedTargets,
+    allPaths,
+    unresolvedTargets,
+    directory,
+  );
+
+  return asTextContentResult(rendered);
+};
+
+// ── Target resolution ──
+
+function resolveTarget(graph: IndexedGraph, target: string): CodeGraphNode[] {
+  // Try as file path first
+  const normalized = normalizePath(target);
+  const pathEntry = graph.pathIndex.get(normalized);
+  if (pathEntry) {
+    const fileNodes: CodeGraphNode[] = [];
+    for (const id of [...pathEntry.functionIds, ...pathEntry.classIds, ...pathEntry.typeIds]) {
+      const node = graph.nodeById.get(id);
+      if (node) fileNodes.push(node);
+    }
+    if (fileNodes.length > 0) return fileNodes;
+  }
+
+  // Try as symbol name
+  return findSymbol(graph, target).slice(0, 3);
+}
+
+// ── BFS path finding ──
+
+interface PathResult {
+  from: string;
+  to: string;
+  path: CodeGraphNode[];
+}
+
+/**
+ * BFS from all source nodes to find the shortest path to any target node.
+ * Traverses both callAdj (out + in) and importAdj (out + in) edges.
+ */
+export function findShortestPath(
+  graph: IndexedGraph,
+  sourceNodes: CodeGraphNode[],
+  targetNodes: CodeGraphNode[],
+  maxDepth: number,
+): CodeGraphNode[] | null {
+  const targetIds = new Set(targetNodes.map(n => n.id));
+  const sourceIds = new Set(sourceNodes.map(n => n.id));
+
+  // Check for direct overlap
+  for (const sid of sourceIds) {
+    if (targetIds.has(sid)) {
+      return [graph.nodeById.get(sid)!];
+    }
+  }
+
+  // BFS from source nodes
+  const visited = new Map<string, string | null>(); // nodeId -> parent nodeId
+  const queue: Array<{ id: string; depth: number }> = [];
+
+  for (const node of sourceNodes) {
+    visited.set(node.id, null);
+    queue.push({ id: node.id, depth: 0 });
+  }
+
+  let head = 0;
+  while (head < queue.length) {
+    const { id, depth } = queue[head++];
+    if (depth >= maxDepth) continue;
+
+    const neighbors = getNeighbors(graph, id);
+    for (const neighborId of neighbors) {
+      if (visited.has(neighborId)) continue;
+      visited.set(neighborId, id);
+
+      if (targetIds.has(neighborId)) {
+        // Reconstruct path
+        return reconstructPath(graph, visited, neighborId);
+      }
+
+      queue.push({ id: neighborId, depth: depth + 1 });
+    }
+  }
+
+  return null;
+}
+
+function getNeighbors(graph: IndexedGraph, nodeId: string): string[] {
+  const neighbors: string[] = [];
+
+  const callAdj = graph.callAdj.get(nodeId);
+  if (callAdj) {
+    neighbors.push(...callAdj.out, ...callAdj.in);
+  }
+
+  const importAdj = graph.importAdj.get(nodeId);
+  if (importAdj) {
+    neighbors.push(...importAdj.out, ...importAdj.in);
+  }
+
+  return neighbors;
+}
+
+function reconstructPath(
+  graph: IndexedGraph,
+  visited: Map<string, string | null>,
+  endId: string,
+): CodeGraphNode[] {
+  const path: CodeGraphNode[] = [];
+  let current: string | null = endId;
+
+  while (current !== null) {
+    const node = graph.nodeById.get(current);
+    if (node) path.unshift(node);
+    current = visited.get(current) ?? null;
+  }
+
+  return path;
+}
+
+// ── Rendering ──
+
+async function renderRelated(
+  graph: IndexedGraph,
+  resolvedTargets: Array<{ query: string; nodes: CodeGraphNode[] }>,
+  paths: PathResult[],
+  unresolvedTargets: string[],
+  directory: string,
+): Promise<string> {
+  const lines: string[] = [];
+
+  // Header
+  const targetNames = resolvedTargets.map(t => t.query);
+  lines.push(`## Connections: ${targetNames.join(' ↔ ')}`);
+  lines.push('');
+
+  if (unresolvedTargets.length > 0) {
+    lines.push(`*Unresolved targets: ${unresolvedTargets.join(', ')}*`);
+    lines.push('');
+  }
+
+  // Resolved targets summary
+  lines.push('### Resolved targets');
+  lines.push('');
+  for (const t of resolvedTargets) {
+    const primary = t.nodes[0];
+    const name = primary.properties?.name as string || t.query;
+    const filePath = normalizePath(primary.properties?.filePath as string || '');
+    const startLine = primary.properties?.startLine as number || 0;
+    const kind = primary.labels?.[0]?.toLowerCase() || 'symbol';
+    lines.push(`- **${name}** (${kind}) — ${filePath}${startLine ? ':' + startLine : ''}`);
+  }
+  lines.push('');
+
+  if (paths.length === 0) {
+    lines.push(`*No connecting paths found within the search depth. The symbols may be in unrelated parts of the codebase. Try increasing max_depth or using \`symbol_context\` on each target individually.*`);
+    return lines.join('\n');
+  }
+
+  // Render each path
+  const bridgeNodeIds = new Set<string>();
+
+  for (const p of paths) {
+    lines.push(`### Path: ${p.from} → ${p.to} (${p.path.length - 1} hops)`);
+    lines.push('');
+
+    for (let i = 0; i < p.path.length; i++) {
+      const node = p.path[i];
+      const name = node.properties?.name as string || '(unknown)';
+      const filePath = normalizePath(node.properties?.filePath as string || '');
+      const startLine = node.properties?.startLine as number || 0;
+      const indent = '  '.repeat(i);
+      const arrow = i === 0 ? '' : '→ ';
+
+      // Determine relationship type
+      let relType = '';
+      if (i > 0) {
+        const prev = p.path[i - 1];
+        relType = getRelationType(graph, prev.id, node.id);
+      }
+
+      const relStr = relType ? ` (${relType})` : '';
+      lines.push(`${indent}${arrow}\`${name}\` — ${filePath}${startLine ? ':' + startLine : ''}${relStr}`);
+
+      // Track bridge nodes (not first or last)
+      if (i > 0 && i < p.path.length - 1) {
+        bridgeNodeIds.add(node.id);
+      }
+    }
+    lines.push('');
+  }
+
+  // Render bridge node source snippets
+  if (bridgeNodeIds.size > 0) {
+    lines.push('### Bridge nodes');
+    lines.push('');
+
+    for (const nodeId of bridgeNodeIds) {
+      const node = graph.nodeById.get(nodeId);
+      if (!node) continue;
+
+      const name = node.properties?.name as string || '(unknown)';
+      const filePath = node.properties?.filePath as string || '';
+      const startLine = node.properties?.startLine as number || 0;
+      const endLine = node.properties?.endLine as number || 0;
+
+      lines.push(`#### ${name}`);
+      lines.push('');
+
+      // Try to read source
+      if (filePath && startLine > 0) {
+        try {
+          const absPath = path.resolve(directory, filePath);
+          const content = await fs.readFile(absPath, 'utf-8');
+          const fileLines = content.split('\n');
+          const end = endLine > 0
+            ? Math.min(endLine, startLine + MAX_BRIDGE_SOURCE_LINES - 1)
+            : startLine + MAX_BRIDGE_SOURCE_LINES - 1;
+          const sourceSlice = fileLines.slice(startLine - 1, end);
+          if (sourceSlice.length > 0) {
+            const lang = languageFromExtension(filePath);
+            lines.push(`\`\`\`${lang}`);
+            lines.push(sourceSlice.join('\n'));
+            lines.push('```');
+            if (endLine > 0 && endLine > startLine + MAX_BRIDGE_SOURCE_LINES - 1) {
+              lines.push(`*... truncated (showing ${MAX_BRIDGE_SOURCE_LINES} of ${endLine - startLine + 1} lines)*`);
+            }
+            lines.push('');
+          }
+        } catch {
+          // File unreadable — skip source
+        }
+      }
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function getRelationType(graph: IndexedGraph, fromId: string, toId: string): string {
+  // Check call adjacency
+  const callAdj = graph.callAdj.get(fromId);
+  if (callAdj) {
+    if (callAdj.out.includes(toId)) return 'calls';
+    if (callAdj.in.includes(toId)) return 'called by';
+  }
+
+  // Check import adjacency
+  const importAdj = graph.importAdj.get(fromId);
+  if (importAdj) {
+    if (importAdj.out.includes(toId)) return 'imports';
+    if (importAdj.in.includes(toId)) return 'imported by';
+  }
+
+  return '';
+}
+
+export default { tool, handler } as Endpoint;

--- a/src/tools/overview.ts
+++ b/src/tools/overview.ts
@@ -30,7 +30,7 @@ import {
 export const tool: Tool = {
   name: 'overview',
   description:
-    `Returns a pre-computed architectural map of the entire codebase: which domains own which files, the most-called hub functions (call graph centrality), file/function/class counts. Sub-second, zero cost. Useful when you need to understand the overall structure before diving in. Skip this if you already know what file or symbol to investigate — use symbol_context or file reading instead.`,
+    `Returns a pre-computed architectural map of the entire codebase: which domains own which files, the most-called hub functions (call graph centrality), file/function/class counts. Sub-second, zero cost. Useful when you need to understand the overall structure before diving in. Skip this if you already know what file or symbol to investigate — use symbol_context, get_related, or file reading instead.`,
   inputSchema: {
     type: 'object',
     properties: {

--- a/src/tools/symbol-context.ts
+++ b/src/tools/symbol-context.ts
@@ -38,7 +38,7 @@ import {
 export const tool: Tool = {
   name: 'symbol_context',
   description:
-    `Strictly better than grep for understanding a function, class, or method. Given a symbol name, instantly returns its source code, definition location, all callers, all callees, architectural domain, and related symbols in the same file -- structural context that grep cannot reconstruct. Sub-second, zero cost. Supports partial matching ("filter" finds "QuerySet.filter", "filter_queryset", etc.) and "ClassName.method" syntax. Use this whenever you have a symbol name from a stack trace, issue, or search result and need to understand how it connects to the rest of the codebase.`,
+    `Strictly better than grep for understanding a function, class, or method. Given a symbol name, instantly returns its source code, definition location, all callers, all callees, architectural domain, and related symbols in the same file -- structural context that grep cannot reconstruct. Sub-second, zero cost. Supports partial matching ("filter" finds "QuerySet.filter", "filter_queryset", etc.) and "ClassName.method" syntax. IMPORTANT: Do NOT chain more than 2 symbol_context calls to trace a call path — use get_related instead, which finds the connecting path in one call. After understanding the code, make your edit and run tests to verify.`,
   inputSchema: {
     type: 'object',
     properties: {
@@ -108,13 +108,15 @@ export const handler: HandlerFunction = async (client, args, defaultWorkdir) => 
   );
   const rendered = renderedParts.join('\n---\n\n');
 
+  const hint = `\n\n---\n*Tip: Need to trace a call chain? Use \`get_related\` with start and end symbols instead of chaining symbol_context calls. Ready to fix? Edit the code and run tests.*`;
+
   if (matches.length > 3) {
     return asTextContentResult(
-      rendered + `\n\n*... and ${matches.length - 3} more matches. Use a more specific name to narrow results.*`
+      rendered + `\n\n*... and ${matches.length - 3} more matches. Use a more specific name to narrow results.*` + hint
     );
   }
 
-  return asTextContentResult(rendered);
+  return asTextContentResult(rendered + hint);
 };
 
 // ── Symbol lookup ──


### PR DESCRIPTION
## Summary
- **#110**: New `get_related` tool — BFS path-finding between 2-5 symbol names or file paths using existing `callAdj` and `importAdj` graphs. Replaces the 5-7 hop sequential `symbol_context` chaining pattern (worst case: 7 calls, 30 iterations, 0 edits) with a single call.
- **#112**: Anti-chasing prompt guidance placed in three surfaces the agent actually reads:
  1. `symbol_context` tool description — "Do NOT chain more than 2 symbol_context calls"
  2. `symbol_context` response body — every response ends with a tip nudging toward `get_related` and test verification
  3. Server instructions — Strategy section with anti-chasing and test-first rules

## Evidence from 500-task eval
- Symbol chasing is the top iteration sink: 5+ MCP calls → 12% resolve rate vs 49% for 1-2 calls
- 14 tasks with 7+ MCP calls made zero edits — pure exploration loops
- MCP exhausts 30-iteration budget on 60% of tasks vs 51.4% baseline

## New files
- `src/tools/get-related.ts` — BFS tool with target resolution, path rendering, bridge node source
- `src/tools/get-related.test.ts` — 8 tests (direct calls, multi-hop, depth limits, reverse edges, imports, shortest path)

## Modified files
- `src/constants.ts` — `MAX_RELATED_TARGETS`, `MAX_RELATED_DEPTH`, `DEFAULT_RELATED_DEPTH`, `MAX_BRIDGE_SOURCE_LINES`
- `src/server.ts` — Register tool, update instructions
- `src/server.integration.test.ts` — 2 tools → 3 tools
- `src/tools/symbol-context.ts` — Anti-chasing in description + response hint
- `src/tools/overview.ts` — Mention `get_related` in description

## Test plan
- [x] `npm run build` compiles without errors
- [x] `npm test` — 70/70 tests pass
- [ ] mcpbr local eval on SWE-bench tasks to verify behavioral improvement

Closes #110, closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `get_related` tool to discover connections between code symbols and files
  * Displays connecting paths with detailed hop information and source code snippets
  * Supports exploring relationships across 2-5 targets with configurable search depth

* **Improvements**
  * Updated `overview` and `symbol_context` tools to recommend `get_related` for tracing call chains
  * Advised against excessive chaining of `symbol_context` calls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->