### PR TITLE
feat: Add generate subcommand for static Supermodel.md output

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,3 +25,19 @@ export const MAX_SYMBOL_CALLERS = 10; // Top N callers to show
 export const MAX_SYMBOL_CALLEES = 10; // Top N callees to show
 export const MAX_SYMBOL_RELATED = 8; // Related symbols in same file
 export const MAX_SOURCE_LINES = 50; // Max lines of source code to include inline
+
+// generate subcommand limits (Supermodel.md renderer)
+export const MAX_GENERATE_HUB_FUNCTIONS = 20;
+export const MAX_GENERATE_SYMBOL_CLASSES = 50;
+export const MAX_GENERATE_SYMBOL_FUNCTIONS = 100;
+export const MAX_GENERATE_HOTSPOTS = 20;
+export const MAX_GENERATE_HOTSPOT_EDGES = 10;
+export const MAX_GENERATE_FILE_MAP_FILES = 200;
+export const MAX_GENERATE_IMPORT_FILES = 50;
+export const MAX_GENERATE_TEST_MAP = 100;
+
+// get_related tool limits
+export const MAX_RELATED_TARGETS = 5; // Max number of targets in a get_related query
+export const MAX_RELATED_DEPTH = 3; // Max BFS depth for connecting paths
+export const DEFAULT_RELATED_DEPTH = 2; // Default BFS depth
+export const MAX_BRIDGE_SOURCE_LINES = 30; // Max source lines for bridge node snippets

--- a/src/generate.test.ts
+++ b/src/generate.test.ts
@@ -1,0 +1,383 @@
+import { describe, it, expect } from '@jest/globals';
+import { renderSupermodelMd } from './generate';
+import { IndexedGraph } from './cache/graph-cache';
+
+describe('generate', () => {
+  describe('renderSupermodelMd', () => {
+    it('should produce output under 50KB', () => {
+      const graph = createRichMockGraph();
+      const md = renderSupermodelMd(graph);
+      const sizeBytes = Buffer.byteLength(md, 'utf-8');
+      expect(sizeBytes).toBeLessThan(50 * 1024);
+    });
+
+    it('should include all sections for a rich graph', () => {
+      const graph = createRichMockGraph();
+      const md = renderSupermodelMd(graph);
+
+      expect(md).toContain('# ');             // Header
+      expect(md).toContain('## Domains');
+      expect(md).toContain('## Hub Functions');
+      expect(md).toContain('## Symbol Index');
+      expect(md).toContain('### Classes');
+      expect(md).toContain('### Functions');
+      expect(md).toContain('## Call Graph Hotspots');
+      expect(md).toContain('## File Map');
+      expect(md).toContain('## Import Graph');
+      expect(md).toContain('## Test Map');
+    });
+
+    it('should include file:line references', () => {
+      const graph = createRichMockGraph();
+      const md = renderSupermodelMd(graph);
+      // file:line pattern like "src/foo.py:10"
+      expect(md).toMatch(/\w+\.\w+:\d+/);
+    });
+
+    it('should render header with summary stats', () => {
+      const graph = createRichMockGraph();
+      const md = renderSupermodelMd(graph);
+
+      expect(md).toContain('| Files |');
+      expect(md).toContain('| Functions |');
+      expect(md).toContain('| Classes |');
+      expect(md).toContain('| Language |');
+    });
+
+    it('should render hub functions as a table', () => {
+      const graph = createRichMockGraph();
+      const md = renderSupermodelMd(graph);
+
+      expect(md).toContain('| Function | Location | Callers | Callees | Domain |');
+    });
+
+    it('should render import graph as a table', () => {
+      const graph = createRichMockGraph();
+      const md = renderSupermodelMd(graph);
+
+      expect(md).toContain('| File | Imported By | Imports |');
+    });
+
+    it('should render test map with source-to-test mappings', () => {
+      const graph = createRichMockGraph();
+      const md = renderSupermodelMd(graph);
+
+      expect(md).toContain('| Source File | Test File |');
+      // Should map test_auth.py -> auth.py
+      expect(md).toContain('src/auth.py');
+      expect(md).toContain('tests/test_auth.py');
+    });
+
+    it('should handle empty graph gracefully', () => {
+      const graph = createEmptyMockGraph();
+      const md = renderSupermodelMd(graph);
+
+      // Should still have a header
+      expect(md).toContain('# ');
+      // Should not crash or produce garbage
+      expect(md.length).toBeGreaterThan(0);
+    });
+
+    it('should handle graph with no domains', () => {
+      const graph = createNoDomainMockGraph();
+      const md = renderSupermodelMd(graph);
+
+      expect(md).not.toContain('## Domains');
+      // Should still render other sections
+      expect(md).toContain('## Hub Functions');
+    });
+
+    it('should render call graph hotspots with callers and callees', () => {
+      const graph = createRichMockGraph();
+      const md = renderSupermodelMd(graph);
+
+      expect(md).toContain('**Callers:**');
+      expect(md).toContain('**Callees:**');
+    });
+
+    it('should render file map grouped by domain', () => {
+      const graph = createRichMockGraph();
+      const md = renderSupermodelMd(graph);
+
+      // Should show domain names as subsections in file map
+      expect(md).toContain('### Auth');
+    });
+  });
+});
+
+// ─── Mock graph builders ─────────────────────────────────────────────────────
+
+function createEmptyMockGraph(): IndexedGraph {
+  return {
+    raw: { graph: { nodes: [], relationships: [] } } as any,
+    nodeById: new Map(),
+    labelIndex: new Map(),
+    pathIndex: new Map(),
+    dirIndex: new Map(),
+    nameIndex: new Map(),
+    callAdj: new Map(),
+    importAdj: new Map(),
+    domainIndex: new Map(),
+    summary: {
+      filesProcessed: 0,
+      classes: 0,
+      functions: 0,
+      types: 0,
+      domains: 0,
+      primaryLanguage: 'unknown',
+      nodeCount: 0,
+      relationshipCount: 0,
+    },
+    cachedAt: new Date().toISOString(),
+    cacheKey: 'test-empty',
+  };
+}
+
+function createNoDomainMockGraph(): IndexedGraph {
+  const nodeById = new Map<string, any>();
+  const labelIndex = new Map<string, string[]>();
+  const pathIndex = new Map<string, any>();
+  const nameIndex = new Map<string, string[]>();
+  const callAdj = new Map<string, any>();
+  const importAdj = new Map<string, any>();
+
+  // Add some functions with callers
+  const funcIds: string[] = [];
+  for (let i = 0; i < 10; i++) {
+    const id = `func${i}`;
+    funcIds.push(id);
+    nodeById.set(id, {
+      id,
+      labels: ['Function'],
+      properties: { name: `func${i}`, filePath: `src/module${i}.ts`, startLine: 10 + i },
+    });
+    nameIndex.set(`func${i}`, [id]);
+    callAdj.set(id, { out: [], in: [] });
+  }
+  labelIndex.set('Function', funcIds);
+
+  // Create call edges: func0 is called by func1..func5
+  for (let i = 1; i <= 5; i++) {
+    callAdj.get(`func0`)!.in.push(`func${i}`);
+    callAdj.get(`func${i}`)!.out.push('func0');
+  }
+  // func1 is called by func6..func8
+  for (let i = 6; i <= 8; i++) {
+    callAdj.get(`func1`)!.in.push(`func${i}`);
+    callAdj.get(`func${i}`)!.out.push('func1');
+  }
+
+  // Add files
+  const fileIds: string[] = [];
+  for (let i = 0; i < 10; i++) {
+    const id = `file${i}`;
+    fileIds.push(id);
+    nodeById.set(id, {
+      id,
+      labels: ['File'],
+      properties: { filePath: `src/module${i}.ts`, name: `module${i}.ts` },
+    });
+    pathIndex.set(`src/module${i}.ts`, {
+      fileId: id,
+      classIds: [],
+      functionIds: [`func${i}`],
+      typeIds: [],
+    });
+    importAdj.set(id, { out: [], in: [] });
+  }
+  labelIndex.set('File', fileIds);
+
+  // Import edges: file0 imported by file1..file4
+  for (let i = 1; i <= 4; i++) {
+    importAdj.get(`file0`)!.in.push(`file${i}`);
+    importAdj.get(`file${i}`)!.out.push('file0');
+  }
+
+  return {
+    raw: { graph: { nodes: [], relationships: [] } } as any,
+    nodeById,
+    labelIndex,
+    pathIndex,
+    dirIndex: new Map(),
+    nameIndex,
+    callAdj,
+    importAdj,
+    domainIndex: new Map(),
+    summary: {
+      filesProcessed: 10,
+      classes: 0,
+      functions: 10,
+      types: 0,
+      domains: 0,
+      primaryLanguage: 'typescript',
+      nodeCount: 20,
+      relationshipCount: 8,
+    },
+    cachedAt: new Date().toISOString(),
+    cacheKey: 'test-no-domain',
+  };
+}
+
+function createRichMockGraph(): IndexedGraph {
+  const nodeById = new Map<string, any>();
+  const labelIndex = new Map<string, string[]>();
+  const pathIndex = new Map<string, any>();
+  const nameIndex = new Map<string, string[]>();
+  const callAdj = new Map<string, any>();
+  const importAdj = new Map<string, any>();
+  const domainIndex = new Map<string, any>();
+
+  const funcIds: string[] = [];
+  const classIds: string[] = [];
+  const fileIds: string[] = [];
+  const domainIds: string[] = [];
+
+  // Create domains
+  for (const domainName of ['Auth', 'Database', 'API']) {
+    const id = `domain_${domainName.toLowerCase()}`;
+    domainIds.push(id);
+    nodeById.set(id, {
+      id,
+      labels: ['Domain'],
+      properties: { name: domainName, description: `The ${domainName} domain handles all ${domainName.toLowerCase()}-related logic` },
+    });
+    nameIndex.set(domainName.toLowerCase(), [id]);
+    domainIndex.set(domainName, { memberIds: [], relationships: [] });
+  }
+  labelIndex.set('Domain', domainIds);
+
+  // Create classes
+  for (let i = 0; i < 5; i++) {
+    const id = `class${i}`;
+    classIds.push(id);
+    const filePath = i < 2 ? 'src/auth.py' : i < 4 ? 'src/db.py' : 'src/api.py';
+    nodeById.set(id, {
+      id,
+      labels: ['Class'],
+      properties: { name: `Class${i}`, filePath, startLine: 10 + i * 20 },
+    });
+    nameIndex.set(`class${i}`, [id]);
+
+    // Assign to domain
+    const domain = i < 2 ? 'Auth' : i < 4 ? 'Database' : 'API';
+    domainIndex.get(domain)!.memberIds.push(id);
+  }
+  labelIndex.set('Class', classIds);
+
+  // Create functions (20 functions across files)
+  const fileNames = ['src/auth.py', 'src/db.py', 'src/api.py', 'src/utils.py', 'src/models.py'];
+  for (let i = 0; i < 20; i++) {
+    const id = `func${i}`;
+    funcIds.push(id);
+    const filePath = fileNames[i % fileNames.length];
+    nodeById.set(id, {
+      id,
+      labels: ['Function'],
+      properties: { name: `function_${i}`, filePath, startLine: 10 + i * 5 },
+    });
+    nameIndex.set(`function_${i}`, [id]);
+    callAdj.set(id, { out: [], in: [] });
+
+    // Assign to domain
+    const domainName = i % 5 < 2 ? 'Auth' : i % 5 < 4 ? 'Database' : 'API';
+    domainIndex.get(domainName)!.memberIds.push(id);
+  }
+  labelIndex.set('Function', funcIds);
+
+  // Create call edges -- func0 is called by many others (hub)
+  for (let i = 1; i <= 10; i++) {
+    callAdj.get('func0')!.in.push(`func${i}`);
+    callAdj.get(`func${i}`)!.out.push('func0');
+  }
+  // func0 calls func11..func14
+  for (let i = 11; i <= 14; i++) {
+    callAdj.get('func0')!.out.push(`func${i}`);
+    callAdj.get(`func${i}`)!.in.push('func0');
+  }
+  // func1 is also a hub
+  for (let i = 5; i <= 12; i++) {
+    if (i === 1) continue;
+    callAdj.get('func1')!.in.push(`func${i}`);
+    callAdj.get(`func${i}`)!.out.push('func1');
+  }
+  // func2 has some callers
+  for (let i = 10; i <= 15; i++) {
+    callAdj.get('func2')!.in.push(`func${i}`);
+    callAdj.get(`func${i}`)!.out.push('func2');
+  }
+
+  // Create files
+  for (const fp of fileNames) {
+    const id = `file_${fp.replace(/[\/\.]/g, '_')}`;
+    fileIds.push(id);
+    nodeById.set(id, {
+      id,
+      labels: ['File'],
+      properties: { filePath: fp, name: fp.split('/').pop() },
+    });
+    importAdj.set(id, { out: [], in: [] });
+
+    // Populate pathIndex
+    const funcsInFile = funcIds.filter(fid => nodeById.get(fid)?.properties?.filePath === fp);
+    const classesInFile = classIds.filter(cid => nodeById.get(cid)?.properties?.filePath === fp);
+    pathIndex.set(fp, {
+      fileId: id,
+      classIds: classesInFile,
+      functionIds: funcsInFile,
+      typeIds: [],
+    });
+  }
+
+  // Add test files
+  const testFiles = ['tests/test_auth.py', 'tests/test_db.py', 'tests/test_api.py'];
+  for (const fp of testFiles) {
+    const id = `file_${fp.replace(/[\/\.]/g, '_')}`;
+    fileIds.push(id);
+    nodeById.set(id, {
+      id,
+      labels: ['File'],
+      properties: { filePath: fp, name: fp.split('/').pop() },
+    });
+    importAdj.set(id, { out: [], in: [] });
+    pathIndex.set(fp, {
+      fileId: id,
+      classIds: [],
+      functionIds: [],
+      typeIds: [],
+    });
+  }
+  labelIndex.set('File', fileIds);
+
+  // Import edges: auth.py is imported by many
+  const authFileId = `file_src_auth_py`;
+  for (let i = 1; i < fileIds.length; i++) {
+    if (fileIds[i] === authFileId) continue;
+    importAdj.get(authFileId)!.in.push(fileIds[i]);
+    const adj = importAdj.get(fileIds[i]);
+    if (adj) adj.out.push(authFileId);
+  }
+
+  return {
+    raw: { repo: 'test-repo', graph: { nodes: [], relationships: [] } } as any,
+    nodeById,
+    labelIndex,
+    pathIndex,
+    dirIndex: new Map(),
+    nameIndex,
+    callAdj,
+    importAdj,
+    domainIndex,
+    summary: {
+      filesProcessed: fileNames.length + testFiles.length,
+      classes: classIds.length,
+      functions: funcIds.length,
+      types: 0,
+      domains: 3,
+      primaryLanguage: 'python',
+      nodeCount: nodeById.size,
+      relationshipCount: 30,
+    },
+    cachedAt: new Date().toISOString(),
+    cacheKey: 'test-rich',
+  };
+}

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -1,0 +1,719 @@
+/**
+ * `generate` subcommand -- produce a static Supermodel.md file from an IndexedGraph.
+ *
+ * The generated markdown contains the most valuable graph data so that an
+ * AI agent can read it once with a native `Read` tool and use native tools
+ * (Grep, Glob, Read) from there -- all parallelizable within a single turn.
+ *
+ * Usage:
+ *   node dist/index.js generate <directory> [--output <path>] [--cache-dir <dir>]
+ *
+ * @module generate
+ */
+
+import { IndexedGraph, normalizePath } from './cache/graph-cache';
+import {
+  MAX_GENERATE_HUB_FUNCTIONS,
+  MAX_GENERATE_SYMBOL_CLASSES,
+  MAX_GENERATE_SYMBOL_FUNCTIONS,
+  MAX_GENERATE_HOTSPOTS,
+  MAX_GENERATE_HOTSPOT_EDGES,
+  MAX_GENERATE_FILE_MAP_FILES,
+  MAX_GENERATE_IMPORT_FILES,
+  MAX_GENERATE_TEST_MAP,
+  MAX_OVERVIEW_DOMAINS,
+  DEFAULT_API_TIMEOUT_MS,
+  CONNECTION_TIMEOUT_MS,
+} from './constants';
+
+// ─── Renderer ────────────────────────────────────────────────────────────────
+
+/**
+ * Render an IndexedGraph to a structured Supermodel.md string.
+ *
+ * Sections: Header, Domains, Hub Functions, Symbol Index, Call Graph Hotspots,
+ * File Map, Import Graph, Test Map.
+ */
+export function renderSupermodelMd(graph: IndexedGraph): string {
+  const sections: string[] = [];
+
+  sections.push(renderHeader(graph));
+  sections.push(renderDomains(graph));
+  sections.push(renderHubFunctions(graph));
+  sections.push(renderSymbolIndex(graph));
+  sections.push(renderCallGraphHotspots(graph));
+  sections.push(renderFileMap(graph));
+  sections.push(renderImportGraph(graph));
+  sections.push(renderTestMap(graph));
+
+  return sections.filter(Boolean).join('\n');
+}
+
+// ─── Section renderers ───────────────────────────────────────────────────────
+
+function renderHeader(graph: IndexedGraph): string {
+  const s = graph.summary;
+  const repoName = graph.raw.repo ? graph.raw.repo.substring(0, 8) : 'Codebase';
+  const lines: string[] = [];
+  lines.push(`# ${repoName}`);
+  lines.push('');
+  lines.push(`| Metric | Value |`);
+  lines.push(`|--------|-------|`);
+  lines.push(`| Files | ${s.filesProcessed} |`);
+  lines.push(`| Functions | ${s.functions} |`);
+  lines.push(`| Classes | ${s.classes} |`);
+  lines.push(`| Language | ${s.primaryLanguage} |`);
+  lines.push(`| Nodes | ${s.nodeCount} |`);
+  lines.push(`| Relationships | ${s.relationshipCount} |`);
+  lines.push('');
+  return lines.join('\n');
+}
+
+function renderDomains(graph: IndexedGraph): string {
+  if (graph.domainIndex.size === 0) return '';
+
+  const lines: string[] = [];
+  lines.push('## Domains');
+  lines.push('');
+
+  const domains = [...graph.domainIndex.entries()]
+    .map(([name, data]) => ({ name, memberCount: data.memberIds.length, memberIds: data.memberIds }))
+    .sort((a, b) => b.memberCount - a.memberCount)
+    .slice(0, MAX_OVERVIEW_DOMAINS);
+
+  for (const domain of domains) {
+    // Get description from domain node
+    const domainNodes = graph.nameIndex.get(domain.name.toLowerCase()) || [];
+    let desc = '';
+    for (const nid of domainNodes) {
+      const node = graph.nodeById.get(nid);
+      if (node?.labels?.[0] === 'Domain') {
+        desc = (node.properties?.description as string) || '';
+        break;
+      }
+    }
+    const descStr = desc ? `: ${truncate(desc, 120)}` : '';
+
+    // Key files for domain
+    const keyFiles = getKeyFilesForDomain(graph, domain.memberIds);
+    const filesStr = keyFiles.length > 0 ? `\n  Key files: ${keyFiles.join(', ')}` : '';
+
+    lines.push(`- **${domain.name}** (${domain.memberCount} members)${descStr}${filesStr}`);
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+function renderHubFunctions(graph: IndexedGraph): string {
+  const hubs = getHubFunctions(graph, MAX_GENERATE_HUB_FUNCTIONS);
+  if (hubs.length === 0) return '';
+
+  const lines: string[] = [];
+  lines.push('## Hub Functions');
+  lines.push('');
+  lines.push('| Function | Location | Callers | Callees | Domain |');
+  lines.push('|----------|----------|---------|---------|--------|');
+
+  for (const hub of hubs) {
+    const domain = getDomainForNode(graph, hub.nodeId) || '';
+    lines.push(`| \`${hub.name}\` | ${hub.filePath}:${hub.line} | ${hub.callerCount} | ${hub.calleeCount} | ${domain} |`);
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+function renderSymbolIndex(graph: IndexedGraph): string {
+  const lines: string[] = [];
+  lines.push('## Symbol Index');
+  lines.push('');
+
+  // Top classes by caller count (how many functions call into their methods)
+  const classIds = graph.labelIndex.get('Class') || [];
+  if (classIds.length > 0) {
+    const classEntries = classIds
+      .map(id => {
+        const node = graph.nodeById.get(id);
+        if (!node) return null;
+        const name = node.properties?.name as string;
+        const filePath = node.properties?.filePath as string;
+        const line = node.properties?.startLine as number;
+        if (!name || !filePath) return null;
+
+        // Count callers across all methods in this class
+        const methodCallers = countClassCallers(graph, id);
+        return { name, filePath: normalizePath(filePath), line: line || 0, callers: methodCallers };
+      })
+      .filter((e): e is NonNullable<typeof e> => e !== null)
+      .sort((a, b) => b.callers - a.callers)
+      .slice(0, MAX_GENERATE_SYMBOL_CLASSES);
+
+    if (classEntries.length > 0) {
+      lines.push('### Classes');
+      lines.push('');
+      lines.push('| Class | Location | Method Callers |');
+      lines.push('|-------|----------|----------------|');
+      for (const cls of classEntries) {
+        lines.push(`| \`${cls.name}\` | ${cls.filePath}:${cls.line} | ${cls.callers} |`);
+      }
+      lines.push('');
+    }
+  }
+
+  // Top functions by caller count
+  const funcEntries = getHubFunctions(graph, MAX_GENERATE_SYMBOL_FUNCTIONS);
+  if (funcEntries.length > 0) {
+    lines.push('### Functions');
+    lines.push('');
+    lines.push('| Function | Location | Callers |');
+    lines.push('|----------|----------|---------|');
+    for (const fn of funcEntries) {
+      lines.push(`| \`${fn.name}\` | ${fn.filePath}:${fn.line} | ${fn.callerCount} |`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+function renderCallGraphHotspots(graph: IndexedGraph): string {
+  const hubs = getHubFunctions(graph, MAX_GENERATE_HOTSPOTS);
+  if (hubs.length === 0) return '';
+
+  const lines: string[] = [];
+  lines.push('## Call Graph Hotspots');
+  lines.push('');
+
+  for (const hub of hubs) {
+    lines.push(`### \`${hub.name}\` (${hub.filePath}:${hub.line})`);
+    lines.push('');
+
+    // Callers
+    const callerNames = resolveNodeNames(graph, hub.callerIds.slice(0, MAX_GENERATE_HOTSPOT_EDGES));
+    if (callerNames.length > 0) {
+      lines.push(`**Callers:** ${callerNames.map(c => `\`${c.name}\` (${c.filePath}:${c.line})`).join(', ')}`);
+    }
+
+    // Callees
+    const calleeNames = resolveNodeNames(graph, hub.calleeIds.slice(0, MAX_GENERATE_HOTSPOT_EDGES));
+    if (calleeNames.length > 0) {
+      lines.push(`**Callees:** ${calleeNames.map(c => `\`${c.name}\` (${c.filePath}:${c.line})`).join(', ')}`);
+    }
+
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+function renderFileMap(graph: IndexedGraph): string {
+  if (graph.domainIndex.size === 0 && graph.pathIndex.size === 0) return '';
+
+  const lines: string[] = [];
+  lines.push('## File Map');
+  lines.push('');
+
+  if (graph.domainIndex.size > 0) {
+    // Group files by domain
+    const domainFiles = new Map<string, { path: string; symbolCount: number }[]>();
+
+    for (const [name, data] of graph.domainIndex) {
+      const files = new Map<string, number>();
+      for (const memberId of data.memberIds) {
+        const node = graph.nodeById.get(memberId);
+        const fp = node?.properties?.filePath as string;
+        if (fp) {
+          const normalized = normalizePath(fp);
+          files.set(normalized, (files.get(normalized) || 0) + 1);
+        }
+      }
+      const sorted = [...files.entries()]
+        .sort((a, b) => b[1] - a[1])
+        .map(([path, count]) => ({ path, symbolCount: count }));
+      if (sorted.length > 0) {
+        domainFiles.set(name, sorted);
+      }
+    }
+
+    // Sort domains by total file count
+    const sortedDomains = [...domainFiles.entries()]
+      .sort((a, b) => b[1].length - a[1].length);
+
+    let totalFiles = 0;
+    for (const [domain, files] of sortedDomains) {
+      if (totalFiles >= MAX_GENERATE_FILE_MAP_FILES) break;
+
+      lines.push(`### ${domain}`);
+      lines.push('');
+      const remaining = MAX_GENERATE_FILE_MAP_FILES - totalFiles;
+      const filesToShow = files.slice(0, remaining);
+      for (const f of filesToShow) {
+        lines.push(`- ${f.path} (${f.symbolCount} symbols)`);
+      }
+      totalFiles += filesToShow.length;
+      if (files.length > filesToShow.length) {
+        lines.push(`- ... and ${files.length - filesToShow.length} more files`);
+      }
+      lines.push('');
+    }
+  } else {
+    // No domains -- just list files by symbol count
+    const fileEntries = [...graph.pathIndex.entries()]
+      .map(([path, entry]) => ({
+        path,
+        symbolCount: entry.classIds.length + entry.functionIds.length + entry.typeIds.length,
+      }))
+      .sort((a, b) => b.symbolCount - a.symbolCount)
+      .slice(0, MAX_GENERATE_FILE_MAP_FILES);
+
+    for (const f of fileEntries) {
+      lines.push(`- ${f.path} (${f.symbolCount} symbols)`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+function renderImportGraph(graph: IndexedGraph): string {
+  // Find files with the most importers (in-degree)
+  const importEntries: { path: string; importers: number; imports: number }[] = [];
+
+  for (const [nodeId, adj] of graph.importAdj) {
+    const node = graph.nodeById.get(nodeId);
+    if (!node) continue;
+    const label = node.labels?.[0];
+    if (label !== 'File' && label !== 'LocalModule') continue;
+
+    const filePath = (node.properties?.filePath as string) || (node.properties?.name as string) || '';
+    if (!filePath) continue;
+
+    importEntries.push({
+      path: normalizePath(filePath),
+      importers: adj.in.length,
+      imports: adj.out.length,
+    });
+  }
+
+  if (importEntries.length === 0) return '';
+
+  importEntries.sort((a, b) => b.importers - a.importers);
+  const top = importEntries.slice(0, MAX_GENERATE_IMPORT_FILES);
+
+  const lines: string[] = [];
+  lines.push('## Import Graph');
+  lines.push('');
+  lines.push('| File | Imported By | Imports |');
+  lines.push('|------|------------|---------|');
+  for (const entry of top) {
+    lines.push(`| ${entry.path} | ${entry.importers} | ${entry.imports} |`);
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+function renderTestMap(graph: IndexedGraph): string {
+  // Heuristic: match test files to source files by naming convention
+  const testFiles: string[] = [];
+  const sourceFiles: string[] = [];
+
+  for (const [path] of graph.pathIndex) {
+    if (isTestFile(path)) {
+      testFiles.push(path);
+    } else {
+      sourceFiles.push(path);
+    }
+  }
+
+  if (testFiles.length === 0) return '';
+
+  const mappings: { source: string; test: string }[] = [];
+
+  for (const testPath of testFiles) {
+    const sourcePath = inferSourceFile(testPath, sourceFiles);
+    if (sourcePath) {
+      mappings.push({ source: sourcePath, test: testPath });
+    }
+  }
+
+  if (mappings.length === 0) return '';
+
+  mappings.sort((a, b) => a.source.localeCompare(b.source));
+  const top = mappings.slice(0, MAX_GENERATE_TEST_MAP);
+
+  const lines: string[] = [];
+  lines.push('## Test Map');
+  lines.push('');
+  lines.push('| Source File | Test File |');
+  lines.push('|------------|-----------|');
+  for (const m of top) {
+    lines.push(`| ${m.source} | ${m.test} |`);
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+interface HubEntry {
+  nodeId: string;
+  name: string;
+  filePath: string;
+  line: number;
+  callerCount: number;
+  calleeCount: number;
+  callerIds: string[];
+  calleeIds: string[];
+}
+
+function getHubFunctions(graph: IndexedGraph, limit: number): HubEntry[] {
+  const hubs: HubEntry[] = [];
+
+  for (const [nodeId, adj] of graph.callAdj) {
+    if (adj.in.length < 2) continue;
+
+    const node = graph.nodeById.get(nodeId);
+    if (!node) continue;
+
+    const name = node.properties?.name as string;
+    const filePath = node.properties?.filePath as string;
+    const line = node.properties?.startLine as number;
+    if (!name || !filePath) continue;
+
+    hubs.push({
+      nodeId,
+      name,
+      filePath: normalizePath(filePath),
+      line: line || 0,
+      callerCount: adj.in.length,
+      calleeCount: adj.out.length,
+      callerIds: adj.in,
+      calleeIds: adj.out,
+    });
+  }
+
+  hubs.sort((a, b) => b.callerCount - a.callerCount);
+  return hubs.slice(0, limit);
+}
+
+function getKeyFilesForDomain(graph: IndexedGraph, memberIds: string[]): string[] {
+  const pathCounts = new Map<string, number>();
+  for (const id of memberIds) {
+    const node = graph.nodeById.get(id);
+    if (!node) continue;
+    const fp = node.properties?.filePath as string;
+    if (fp) {
+      const normalized = normalizePath(fp);
+      pathCounts.set(normalized, (pathCounts.get(normalized) || 0) + 1);
+    }
+  }
+  return [...pathCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 3)
+    .map(([p]) => p);
+}
+
+function getDomainForNode(graph: IndexedGraph, nodeId: string): string | null {
+  for (const [name, data] of graph.domainIndex) {
+    if (data.memberIds.includes(nodeId)) return name;
+  }
+  return null;
+}
+
+function countClassCallers(graph: IndexedGraph, classId: string): number {
+  const node = graph.nodeById.get(classId);
+  if (!node) return 0;
+
+  const filePath = node.properties?.filePath as string;
+  const className = node.properties?.name as string;
+  if (!filePath || !className) return 0;
+
+  // Find functions in the same file that might be methods of this class
+  const normalized = normalizePath(filePath);
+  const pathEntry = graph.pathIndex.get(normalized);
+  if (!pathEntry) return 0;
+
+  let totalCallers = 0;
+  for (const funcId of pathEntry.functionIds) {
+    const funcNode = graph.nodeById.get(funcId);
+    if (!funcNode) continue;
+
+    // Heuristic: function is a method if its name contains the class name or
+    // if it's in the same file. This is a rough approximation.
+    const adj = graph.callAdj.get(funcId);
+    if (adj) {
+      totalCallers += adj.in.length;
+    }
+  }
+
+  return totalCallers;
+}
+
+function resolveNodeNames(graph: IndexedGraph, nodeIds: string[]): { name: string; filePath: string; line: number }[] {
+  const results: { name: string; filePath: string; line: number }[] = [];
+  for (const id of nodeIds) {
+    const node = graph.nodeById.get(id);
+    if (!node) continue;
+    const name = node.properties?.name as string;
+    const filePath = node.properties?.filePath as string;
+    const line = node.properties?.startLine as number;
+    if (name && filePath) {
+      results.push({ name, filePath: normalizePath(filePath), line: line || 0 });
+    }
+  }
+  return results;
+}
+
+function isTestFile(path: string): boolean {
+  const lower = path.toLowerCase();
+  // Common test file patterns
+  return (
+    lower.includes('/test/') ||
+    lower.includes('/tests/') ||
+    lower.includes('/__tests__/') ||
+    lower.includes('.test.') ||
+    lower.includes('.spec.') ||
+    lower.includes('_test.') ||
+    lower.match(/\/test_[^\/]+$/) !== null
+  );
+}
+
+function inferSourceFile(testPath: string, sourceFiles: string[]): string | null {
+  // Extract the base name and try common transformations
+  const parts = testPath.split('/');
+  const fileName = parts[parts.length - 1];
+
+  // Remove test prefixes/suffixes
+  const candidates: string[] = [];
+
+  // test_foo.py -> foo.py
+  if (fileName.startsWith('test_')) {
+    candidates.push(fileName.substring(5));
+  }
+  // foo_test.py -> foo.py
+  if (fileName.includes('_test.')) {
+    candidates.push(fileName.replace('_test.', '.'));
+  }
+  // foo.test.ts -> foo.ts
+  if (fileName.includes('.test.')) {
+    candidates.push(fileName.replace('.test.', '.'));
+  }
+  // foo.spec.ts -> foo.spec
+  if (fileName.includes('.spec.')) {
+    candidates.push(fileName.replace('.spec.', '.'));
+  }
+  // test/test_foo.py -> try matching to foo.py in src/
+  // tests/foo_test.go -> try matching to foo.go in src/
+
+  if (candidates.length === 0) return null;
+
+  // Try to find a source file matching any candidate
+  for (const candidate of candidates) {
+    const match = sourceFiles.find(sf => {
+      const sfParts = sf.split('/');
+      return sfParts[sfParts.length - 1] === candidate;
+    });
+    if (match) return match;
+  }
+
+  return null;
+}
+
+function truncate(s: string, maxLen: number): string {
+  if (s.length <= maxLen) return s;
+  return s.substring(0, maxLen - 3) + '...';
+}
+
+// ─── CLI Handler ─────────────────────────────────────────────────────────────
+
+/**
+ * Handle the `generate` subcommand.
+ * Parses args, loads/creates graph, calls renderSupermodelMd, writes output.
+ */
+export async function handleGenerate(args: string[]) {
+  if (args.length === 0) {
+    console.error('Usage: supermodel-mcp generate <directory> [--output <path>] [--cache-dir <dir>]');
+    console.error('');
+    console.error('Generate a Supermodel.md file from a code graph.');
+    console.error('');
+    console.error('Options:');
+    console.error('  --output <path>      Output file path (default: <directory>/Supermodel.md)');
+    console.error('  --cache-dir <dir>    Directory with pre-computed graph cache');
+    console.error('');
+    console.error('Environment:');
+    console.error('  SUPERMODEL_API_KEY   Required if no cached graph exists.');
+    console.error('  SUPERMODEL_CACHE_DIR Alternative to --cache-dir.');
+    process.exit(1);
+  }
+
+  // Parse args
+  let directory = '';
+  let outputPath = '';
+  let cacheDir = process.env.SUPERMODEL_CACHE_DIR || '';
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--output' && i + 1 < args.length) {
+      outputPath = args[++i];
+    } else if (args[i] === '--cache-dir' && i + 1 < args.length) {
+      cacheDir = args[++i];
+    } else if (!args[i].startsWith('--')) {
+      directory = args[i];
+    }
+  }
+
+  if (!directory) {
+    console.error('Error: directory argument is required');
+    process.exit(1);
+  }
+
+  const { resolve, basename, join } = require('path');
+  const { execSync } = require('child_process');
+  const { existsSync } = require('fs');
+  const { writeFile, readFile, mkdir } = require('fs/promises');
+  const resolvedDir = resolve(directory);
+
+  if (!outputPath) {
+    outputPath = join(resolvedDir, 'Supermodel.md');
+  }
+
+  // Detect repo name
+  let detectedName = basename(resolvedDir);
+  try {
+    const remote = execSync('git remote get-url origin', {
+      cwd: resolvedDir, encoding: 'utf-8', timeout: 2000,
+    }).trim();
+    const match = remote.match(/\/([^\/]+?)(?:\.git)?$/);
+    if (match) detectedName = match[1];
+  } catch {}
+
+  // Get commit hash
+  let commitHash = '';
+  try {
+    commitHash = execSync('git rev-parse --short HEAD', {
+      cwd: resolvedDir, encoding: 'utf-8', timeout: 2000,
+    }).trim();
+  } catch {}
+
+  const name = commitHash ? `${detectedName}_${commitHash}` : detectedName;
+
+  // Try loading from cache first
+  const { buildIndexes, loadCacheFromDisk, saveCacheToDisk, sanitizeFileName, GraphCache } = require('./cache/graph-cache');
+
+  let graph: IndexedGraph | null = null;
+
+  if (cacheDir) {
+    console.error(`Looking for cached graph in: ${cacheDir}`);
+    const tempCache = new GraphCache();
+    const repoMap = await loadCacheFromDisk(cacheDir, tempCache);
+
+    if (repoMap.size > 0) {
+      // Try to find matching graph
+      const lowerName = detectedName.toLowerCase();
+      graph = repoMap.get(lowerName) || null;
+
+      if (!graph && commitHash) {
+        graph = repoMap.get(`commit:${commitHash}`) || null;
+      }
+
+      // If only one graph, use it
+      if (!graph && repoMap.size <= 3) {
+        const uniqueGraphs = new Set([...repoMap.values()]);
+        if (uniqueGraphs.size === 1) {
+          graph = [...uniqueGraphs][0];
+        }
+      }
+
+      if (graph) {
+        console.error(`Found cached graph: ${graph.summary.nodeCount} nodes`);
+      }
+    }
+  }
+
+  // If no cache, call API
+  if (!graph) {
+    if (!process.env.SUPERMODEL_API_KEY) {
+      console.error('Error: No cached graph found and SUPERMODEL_API_KEY not set.');
+      console.error('Either provide a --cache-dir with a pre-computed graph or set SUPERMODEL_API_KEY.');
+      process.exit(1);
+    }
+
+    console.error(`Generating graph for: ${resolvedDir}`);
+
+    const { Configuration, DefaultApi, SupermodelClient } = require('@supermodeltools/sdk');
+    const { zipRepository } = require('./utils/zip-repository');
+    const { Blob } = require('buffer');
+    const { generateIdempotencyKey } = require('./utils/api-helpers');
+    const { Agent } = require('undici');
+
+    const parsedTimeout = parseInt(process.env.SUPERMODEL_TIMEOUT_MS || '', 10);
+    const timeoutMs = Number.isFinite(parsedTimeout) && parsedTimeout > 0
+      ? parsedTimeout
+      : DEFAULT_API_TIMEOUT_MS;
+
+    const httpAgent = new Agent({
+      headersTimeout: timeoutMs,
+      bodyTimeout: timeoutMs,
+      connectTimeout: CONNECTION_TIMEOUT_MS,
+    });
+
+    const fetchWithTimeout: typeof fetch = (url: any, init: any) => {
+      return fetch(url, { ...init, dispatcher: httpAgent } as any);
+    };
+
+    const config = new Configuration({
+      basePath: process.env.SUPERMODEL_BASE_URL || 'https://api.supermodeltools.com',
+      apiKey: process.env.SUPERMODEL_API_KEY,
+      fetchApi: fetchWithTimeout,
+    });
+
+    const api = new DefaultApi(config);
+    const client = new SupermodelClient(api);
+
+    // Step 1: Zip
+    console.error('Step 1/3: Creating ZIP archive...');
+    const zipResult = await zipRepository(resolvedDir);
+    console.error(`  ZIP created: ${zipResult.fileCount} files, ${(zipResult.sizeBytes / 1024 / 1024).toFixed(1)} MB`);
+
+    // Step 2: API call
+    console.error('Step 2/3: Analyzing codebase...');
+    const idempotencyKey = generateIdempotencyKey(resolvedDir);
+
+    let progressInterval: NodeJS.Timeout | null = null;
+    let elapsed = 0;
+    progressInterval = setInterval(() => {
+      elapsed += 15;
+      console.error(`  Analysis in progress... (${elapsed}s elapsed)`);
+    }, 15000);
+
+    let response: any;
+    try {
+      const fileBuffer = await readFile(zipResult.path);
+      const fileBlob = new Blob([fileBuffer], { type: 'application/zip' });
+      response = await client.generateSupermodelGraph(fileBlob, { idempotencyKey });
+    } finally {
+      if (progressInterval) clearInterval(progressInterval);
+      await zipResult.cleanup();
+    }
+
+    graph = buildIndexes(response, `generate:${name}`) as IndexedGraph;
+    console.error(`  Analysis complete: ${graph!.summary.nodeCount} nodes, ${graph!.summary.relationshipCount} relationships`);
+
+    // Save cache for reuse
+    if (cacheDir) {
+      console.error('Step 3/3: Saving cache...');
+      const savedPath = await saveCacheToDisk(cacheDir, name, response, commitHash || undefined);
+      console.error(`  Saved to: ${savedPath}`);
+    }
+  }
+
+  // Render and write
+  console.error('Rendering Supermodel.md...');
+  const markdown = renderSupermodelMd(graph!);
+
+  // Ensure output directory exists
+  const outputDir = require('path').dirname(outputPath);
+  await mkdir(outputDir, { recursive: true });
+
+  await writeFile(outputPath, markdown, 'utf-8');
+  const sizeKB = (Buffer.byteLength(markdown, 'utf-8') / 1024).toFixed(1);
+  console.error(`Written to: ${outputPath} (${sizeKB} KB)`);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@
  * Usage:
  *   node dist/index.js [workdir] [--no-api-fallback]  -- Start MCP server
  *   node dist/index.js precache <dir> [--output-dir <dir>]  -- Pre-compute graph for a repo
+ *   node dist/index.js generate <dir> [--output <path>] [--cache-dir <dir>]  -- Generate Supermodel.md
  *
  * @module index
  */
@@ -17,6 +18,13 @@ async function main() {
   // Handle precache subcommand
   if (args[0] === 'precache') {
     await handlePrecache(args.slice(1));
+    return;
+  }
+
+  // Handle generate subcommand
+  if (args[0] === 'generate') {
+    const { handleGenerate } = require('./generate');
+    await handleGenerate(args.slice(1));
     return;
   }
 


### PR DESCRIPTION
## Summary

- Adds `generate` CLI subcommand that renders an IndexedGraph into a structured `Supermodel.md` file
- Enables agents to read codebase architecture data with native `Read` tools instead of serialized MCP calls, allowing full tool parallelism within a single agent turn
- Includes 8 sections: header, domains, hub functions, symbol index, call graph hotspots, file map, import graph, and test map — all with `file:line` references for direct `Read` access
- Companion mcpbr change: [greynewell/mcpbr#445](https://github.com/greynewell/mcpbr/pull/445) (merged) adds `setup_only` mode to run `generate` as a setup command without starting an MCP server

Closes #119

## Test plan

- [x] Unit tests pass (`npm test` — `src/generate.test.ts` covers renderer output, size limits, all sections, file:line format, test map heuristic)
- [x] Build succeeds (`npm run build`)
- [x] CLI integration: `node dist/index.js generate <repo> --output /tmp/Supermodel.md` produces valid markdown under 50KB
- [x] SWE-bench gate eval (2 tasks): 2/2 PASS with Supermodel.md mode, $0.64/task, ~4m20s/task

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `generate` subcommand that analyzes code repositories and produces comprehensive Markdown documentation featuring call graphs, symbol indexes, file maps, import graphs, test mappings, and hotspot analysis.
  * Supports API-based generation with local caching for performance optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->