### PR TITLE
feat: Batch symbol_context, inject overview into instructions, remove overview tool

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,3 +25,8 @@ export const MAX_SYMBOL_CALLERS = 10; // Top N callers to show
 export const MAX_SYMBOL_CALLEES = 10; // Top N callees to show
 export const MAX_SYMBOL_RELATED = 8; // Related symbols in same file
 export const MAX_SOURCE_LINES = 50; // Max lines of source code to include inline
+
+// Batch symbol_context limits
+export const MAX_BATCH_SYMBOLS = 10; // Max symbols per batch call
+export const MAX_BRIEF_CALLERS = 5; // Callers shown in brief mode
+export const MAX_BRIEF_CALLEES = 5; // Callees shown in brief mode

--- a/src/server.integration.test.ts
+++ b/src/server.integration.test.ts
@@ -135,32 +135,30 @@ describe('MCP Server Integration', () => {
   });
 
   describe('tools/list', () => {
-    it('should list exactly 2 tools', async () => {
+    it('should list exactly 1 tool', async () => {
       const result = await sendRequest('tools/list', {});
 
       expect(result.tools).toBeDefined();
       expect(Array.isArray(result.tools)).toBe(true);
-      expect(result.tools.length).toBe(2);
+      expect(result.tools.length).toBe(1);
     });
 
-    it('should include overview and symbol_context tools', async () => {
+    it('should include symbol_context tool', async () => {
       const result = await sendRequest('tools/list', {});
       const toolNames = result.tools.map((t: any) => t.name);
 
-      expect(toolNames).toContain('overview');
       expect(toolNames).toContain('symbol_context');
     });
 
-    it('should have correct schema for tools', async () => {
+    it('should have correct schema for symbol_context', async () => {
       const result = await sendRequest('tools/list', {});
-
-      const overviewTool = result.tools.find((t: any) => t.name === 'overview');
-      expect(overviewTool.inputSchema.properties.directory).toBeDefined();
 
       const symbolTool = result.tools.find((t: any) => t.name === 'symbol_context');
       expect(symbolTool.inputSchema.properties.symbol).toBeDefined();
+      expect(symbolTool.inputSchema.properties.symbols).toBeDefined();
+      expect(symbolTool.inputSchema.properties.brief).toBeDefined();
       expect(symbolTool.inputSchema.properties.directory).toBeDefined();
-      expect(symbolTool.inputSchema.required).toContain('symbol');
+      expect(symbolTool.inputSchema.required).toEqual([]);
     });
 
     it('should have readOnlyHint annotation on all tools', async () => {
@@ -174,25 +172,21 @@ describe('MCP Server Integration', () => {
   });
 
   describe('tools/call validation', () => {
-    it('should return NO_CACHE error for overview when no cache and API disabled', async () => {
-      // Server runs with --no-api-fallback, so overview with no pre-computed
-      // cache returns a fast, deterministic NO_CACHE error (no API call).
-      const result = await sendRequest('tools/call', {
-        name: 'overview',
-        arguments: {}
-      });
-
-      expect(result.content).toBeDefined();
-      expect(result.content[0].type).toBe('text');
-      const parsed = JSON.parse(result.content[0].text);
-      expect(parsed.error).toBeDefined();
-      expect(parsed.error.code).toBe('NO_CACHE');
-    });
-
     it('should return validation error for missing symbol on symbol_context', async () => {
       const result = await sendRequest('tools/call', {
         name: 'symbol_context',
         arguments: { directory: '/tmp' }
+      });
+
+      expect(result.content).toBeDefined();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error.code).toBe('MISSING_SYMBOL');
+    });
+
+    it('should return validation error for empty symbols array on symbol_context', async () => {
+      const result = await sendRequest('tools/call', {
+        name: 'symbol_context',
+        arguments: { symbols: [], directory: '/tmp' }
       });
 
       expect(result.content).toBeDefined();

--- a/src/tools/overview.ts
+++ b/src/tools/overview.ts
@@ -71,7 +71,7 @@ export const handler: HandlerFunction = async (client, args, defaultWorkdir) => 
 
 // ── Rendering ──
 
-function renderOverview(graph: IndexedGraph): string {
+export function renderOverview(graph: IndexedGraph): string {
   const s = graph.summary;
   const lines: string[] = [];
 

--- a/src/tools/symbol-context.ts
+++ b/src/tools/symbol-context.ts
@@ -33,12 +33,15 @@ import {
   MAX_SYMBOL_CALLEES,
   MAX_SYMBOL_RELATED,
   MAX_SOURCE_LINES,
+  MAX_BATCH_SYMBOLS,
+  MAX_BRIEF_CALLERS,
+  MAX_BRIEF_CALLEES,
 } from '../constants';
 
 export const tool: Tool = {
   name: 'symbol_context',
   description:
-    `Strictly better than grep for understanding a function, class, or method. Given a symbol name, instantly returns its source code, definition location, all callers, all callees, architectural domain, and related symbols in the same file -- structural context that grep cannot reconstruct. Sub-second, zero cost. Supports partial matching ("filter" finds "QuerySet.filter", "filter_queryset", etc.) and "ClassName.method" syntax. Use this whenever you have a symbol name from a stack trace, issue, or search result and need to understand how it connects to the rest of the codebase.`,
+    `Strictly better than grep for understanding a function, class, or method. Given a symbol name, instantly returns its source code, definition location, all callers, all callees, architectural domain, and related symbols in the same file -- structural context that grep cannot reconstruct. Sub-second, zero cost, read-only. Supports partial matching ("filter" finds "QuerySet.filter", "filter_queryset", etc.) and "ClassName.method" syntax. You can issue multiple calls in parallel (read-only, no side effects) or batch symbols into one call via the "symbols" array.`,
   inputSchema: {
     type: 'object',
     properties: {
@@ -47,13 +50,25 @@ export const tool: Tool = {
         description:
           'Name of the function, class, or method to look up. Supports "ClassName.method" syntax.',
       },
+      symbols: {
+        type: 'array',
+        items: { type: 'string' },
+        description:
+          'Array of symbol names to look up in parallel. More efficient than multiple calls.',
+        maxItems: 10,
+      },
       directory: {
         type: 'string',
         description:
           'Path to the repository directory. Omit if the MCP server was started with a default workdir.',
       },
+      brief: {
+        type: 'boolean',
+        description:
+          'Return compact output (definition + callers only, no source code). Recommended when looking up 3+ symbols.',
+      },
     },
-    required: ['symbol'],
+    required: [],
   },
   annotations: {
     readOnlyHint: true,
@@ -61,19 +76,32 @@ export const tool: Tool = {
 };
 
 export const handler: HandlerFunction = async (client, args, defaultWorkdir) => {
-  const symbol = typeof args?.symbol === 'string' ? args.symbol.trim() : '';
-  const rawDir = args?.directory as string | undefined;
-  const directory = (rawDir && rawDir.trim()) || defaultWorkdir || process.cwd();
+  // Extract symbol list: prefer `symbols` array, fall back to single `symbol`
+  let symbolList: string[];
+  const symbolsArg = args?.symbols;
+  const symbolArg = typeof args?.symbol === 'string' ? args.symbol.trim() : '';
 
-  if (!symbol) {
+  if (Array.isArray(symbolsArg) && symbolsArg.length > 0) {
+    symbolList = symbolsArg
+      .filter((s): s is string => typeof s === 'string')
+      .map(s => s.trim())
+      .filter(s => s.length > 0)
+      .slice(0, MAX_BATCH_SYMBOLS);
+  } else if (symbolArg) {
+    symbolList = [symbolArg];
+  } else {
     return asErrorResult({
       type: 'validation_error',
-      message: 'Missing required "symbol" parameter.',
+      message: 'Missing required "symbol" or "symbols" parameter.',
       code: 'MISSING_SYMBOL',
       recoverable: false,
       suggestion: 'Provide the name of a function, class, or method to look up.',
     });
   }
+
+  const brief = !!args?.brief;
+  const rawDir = args?.directory as string | undefined;
+  const directory = (rawDir && rawDir.trim()) || defaultWorkdir || process.cwd();
 
   if (!directory || typeof directory !== 'string') {
     return asErrorResult({
@@ -92,32 +120,40 @@ export const handler: HandlerFunction = async (client, args, defaultWorkdir) => 
     return asErrorResult(classifyApiError(error));
   }
 
-  // Find the symbol
-  const matches = findSymbol(graph, symbol);
+  const isBatch = symbolList.length > 1;
+  const useBrief = brief || isBatch;
 
-  if (matches.length === 0) {
-    return asTextContentResult(
-      `No symbol matching "${symbol}" found in the code graph.\n\n` +
-      `Try:\n` +
-      `- A different spelling or casing\n` +
-      `- Just the function name without the class prefix\n` +
-      `- Use the \`overview\` tool to see available domains and key functions`
-    );
+  const allRendered: string[] = [];
+  for (const sym of symbolList) {
+    const matches = findSymbol(graph, sym);
+
+    if (matches.length === 0) {
+      allRendered.push(
+        `## ${sym}\n\nNo symbol matching "${sym}" found in the code graph.`
+      );
+      continue;
+    }
+
+    if (useBrief) {
+      // Brief mode: compact output for each top match
+      const parts = matches.slice(0, 3).map(node => renderBriefSymbolContext(graph, node));
+      allRendered.push(parts.join('\n---\n\n'));
+      if (matches.length > 3) {
+        allRendered.push(`*... and ${matches.length - 3} more matches for "${sym}".*`);
+      }
+    } else {
+      // Full mode: detailed output (single symbol, not brief)
+      const parts = await Promise.all(
+        matches.slice(0, 3).map(node => renderSymbolContext(graph, node, directory))
+      );
+      allRendered.push(parts.join('\n---\n\n'));
+      if (matches.length > 3) {
+        allRendered.push(`*... and ${matches.length - 3} more matches. Use a more specific name to narrow results.*`);
+      }
+    }
   }
 
-  // Render results for top matches (usually 1, sometimes a few)
-  const renderedParts = await Promise.all(
-    matches.slice(0, 3).map(node => renderSymbolContext(graph, node, directory))
-  );
-  const rendered = renderedParts.join('\n---\n\n');
-
-  if (matches.length > 3) {
-    return asTextContentResult(
-      rendered + `\n\n*... and ${matches.length - 3} more matches. Use a more specific name to narrow results.*`
-    );
-  }
-
-  return asTextContentResult(rendered);
+  return asTextContentResult(allRendered.join('\n\n---\n\n'));
 };
 
 // ── Symbol lookup ──
@@ -222,6 +258,52 @@ function callerCount(graph: IndexedGraph, node: CodeGraphNode): number {
 }
 
 // ── Rendering ──
+
+export function renderBriefSymbolContext(graph: IndexedGraph, node: CodeGraphNode): string {
+  const name = node.properties?.name as string || '(unknown)';
+  const rawFilePath = node.properties?.filePath as string || '';
+  const filePath = normalizePath(rawFilePath);
+  const startLine = node.properties?.startLine as number || 0;
+  const endLine = node.properties?.endLine as number || 0;
+  const kind = node.properties?.kind as string || node.labels?.[0]?.toLowerCase() || 'symbol';
+  const language = node.properties?.language as string || '';
+
+  const lines: string[] = [];
+
+  lines.push(`## ${name}`);
+  lines.push(`**Defined in:** ${filePath}${startLine ? ':' + startLine : ''}${endLine ? '-' + endLine : ''}`);
+  lines.push(`**Type:** ${kind}${language ? ' (' + language + ')' : ''}`);
+
+  const domain = findDomain(graph, node.id);
+  if (domain) {
+    lines.push(`**Domain:** ${domain}`);
+  }
+
+  // Callers (inline, max MAX_BRIEF_CALLERS)
+  const adj = graph.callAdj.get(node.id);
+  if (adj && adj.in.length > 0) {
+    const callerNames = adj.in
+      .map(id => graph.nodeById.get(id))
+      .filter((n): n is CodeGraphNode => !!n)
+      .map(n => `\`${n.properties?.name as string || '(unknown)'}\``)
+      .slice(0, MAX_BRIEF_CALLERS);
+    const suffix = adj.in.length > MAX_BRIEF_CALLERS ? `, ... (${adj.in.length} total)` : '';
+    lines.push(`**Called by:** ${callerNames.join(', ')}${suffix}`);
+  }
+
+  // Callees (inline, max MAX_BRIEF_CALLEES)
+  if (adj && adj.out.length > 0) {
+    const calleeNames = adj.out
+      .map(id => graph.nodeById.get(id))
+      .filter((n): n is CodeGraphNode => !!n)
+      .map(n => `\`${n.properties?.name as string || '(unknown)'}\``)
+      .slice(0, MAX_BRIEF_CALLEES);
+    const suffix = adj.out.length > MAX_BRIEF_CALLEES ? `, ... (${adj.out.length} total)` : '';
+    lines.push(`**Calls:** ${calleeNames.join(', ')}${suffix}`);
+  }
+
+  return lines.join('\n');
+}
 
 export async function renderSymbolContext(graph: IndexedGraph, node: CodeGraphNode, directory: string): Promise<string> {
   const name = node.properties?.name as string || '(unknown)';


### PR DESCRIPTION
## Summary

Redesigns the MCP server for maximum SWE-bench performance by eliminating sequential tool-call overhead:

- **Inject overview into instructions**: `renderOverview` output is appended to MCP server instructions at handshake time, so the agent gets the codebase architecture map for free — no tool call needed
- **Remove `overview` tool**: With overview in instructions, the separate tool is no longer registered (1 tool instead of 2)
- **Batch `symbol_context`**: New `symbols` array parameter allows looking up up to 10 symbols in a single call. Combined with `readOnlyHint: true`, agents can also issue multiple `symbol_context` calls in parallel
- **Brief mode**: New `brief: true` parameter returns compact output (~5-10 lines per symbol vs ~30-50) — definition location, domain, callers/callees lists, no source code. Recommended when looking up 3+ symbols
- **Updated instructions**: Server instructions now emphasize parallel execution, batch workflows, and the 2-turn MCP budget

### Before
Agent calls `overview` (turn 1) → reads result → calls `symbol_context` one at a time (turns 2-3) → starts coding (turn 4)

### After  
Agent receives overview in instructions (turn 0) → calls `symbol_context` with batch of 5-10 symbols (turn 1) → starts coding (turn 2)

## Changed files

| File | Change |
|------|--------|
| `src/constants.ts` | Add `MAX_BATCH_SYMBOLS`, `MAX_BRIEF_CALLERS`, `MAX_BRIEF_CALLEES` |
| `src/tools/overview.ts` | Export `renderOverview` for use in server.ts |
| `src/tools/symbol-context.ts` | Add `symbols`/`brief` params, batch handler, `renderBriefSymbolContext()` |
| `src/server.ts` | Import `renderOverview`, add `injectOverviewInstructions()`, update instructions, remove overview tool |
| `src/server.integration.test.ts` | Update for 1 tool, new schema assertions, batch validation test |
| `src/tools/symbol-context.test.ts` | Add `renderBriefSymbolContext` tests |

## Test plan
- [x] `npm run build` compiles cleanly
- [x] All 65 tests pass (`npm test`)
- [x] Local mcpbr trial confirmed batch `symbols` parameter works (9 symbols explored in 3 calls on first task)
- [ ] Verify `tools/list` returns updated schema with `symbols` and `brief` properties
- [ ] Verify overview appears in server instructions when precache exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch symbol lookups (multiple symbols per request) and a compact "brief" symbol summary mode.
  * Server now injects a rendered codebase overview into assistant instructions when applicable.

* **Bug Fixes / Tests**
  * Integration tests updated for the reduced tool set and revised error expectations; added assertion for read-only hint annotations.
  * Added unit tests for the compact summary and truncation behavior.

* **Chores**
  * Added configurable limits for batch size and brief-mode caller/callee counts; added read-only metadata to tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->