### PR TITLE
Minimize agent_prompt to restore parallel tool calling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ OVERNIGHT_SUMMARY.md
 START_HERE.md
 .claude_notes
 mcpbr-*.yaml
+!mcpbr-config.yaml
 *-benchmark*.sh
 *-monitor*.sh
 *-comparison*.sh

--- a/mcpbr-config.yaml
+++ b/mcpbr-config.yaml
@@ -1,6 +1,11 @@
-# Supermodel MCP server configuration for mcpbr
+# Recommended Supermodel MCP server configuration for mcpbr
 #
-# This uses the Supermodel codebase analysis MCP server.
+# Best-practice config: minimal agent_prompt to avoid suppressing parallel
+# tool calls. All workflow guidance lives in the MCP server's instructions
+# field (see src/server.ts), which does not inhibit parallelism.
+#
+# See: https://github.com/supermodeltools/mcp/issues/123
+#
 # Requires SUPERMODEL_API_KEY environment variable.
 
 mcp_server:
@@ -8,14 +13,14 @@ mcp_server:
   command: "npx"
   args:
     - "-y"
-    - "@supermodeltools/mcp-server@0.9.2"
+    - "@supermodeltools/mcp-server@0.9.4"
     - "{workdir}"
     - "--precache"
   env:
     SUPERMODEL_API_KEY: "${SUPERMODEL_API_KEY}"
     SUPERMODEL_BASE_URL: "https://api.supermodeltools.com"
     SUPERMODEL_CACHE_DIR: "/tmp/supermodel-cache"
-  setup_command: "npx -y @supermodeltools/mcp-server@0.9.2 precache {workdir} --output-dir /tmp/supermodel-cache"
+  setup_command: "npx -y @supermodeltools/mcp-server@0.9.4 precache {workdir} --output-dir /tmp/supermodel-cache"
   setup_timeout_ms: 900000
 
 provider: "anthropic"
@@ -32,22 +37,12 @@ max_concurrent: 2
 
 max_iterations: 30
 
+# Minimal agent_prompt: just the problem statement + repo location.
+# Workflow guidance comes from the MCP server instructions field, which
+# preserves the agent's natural parallel tool-calling behavior.
 agent_prompt: |
   {problem_statement}
 
-  ## Workflow (follow this order)
-
-  1. ORIENT: Call `overview` to see the codebase architecture. Identify which domain and files relate to the issue.
-  2. LOCATE: Call `symbol_context` on 1-2 key symbols from the issue (function names, class names, error trace). Read the callers/callees to understand the change surface.
-  3. STOP EXPLORING: Do not call MCP tools more than 3 times total. You now have enough context. Use Read/Grep only for targeted verification.
-  4. FIX: Make the minimal code change that addresses the root cause. Prefer modifying existing logic over adding new code.
-  5. TEST: Run the project's existing test suite to verify your fix. Use the repo's test runner (e.g., `python -m pytest <test_file>`). NEVER write standalone test scripts -- they will fail on missing dependencies. Find the relevant test file from the MCP output or with Grep, then run it.
-  6. REGRESSION CHECK: Run the full related test module to ensure no regressions. If tests fail, read the failure output and iterate on your fix.
-
-  ## Anti-patterns to avoid
-  - Do NOT chase symbol after symbol (>3 MCP calls). Diminishing returns after 2 calls.
-  - Do NOT write test_bug.py or test_fix.py scripts. The workspace lacks pip-installed dependencies. Use the project's own tests.
-  - Do NOT spend iterations on TodoWrite planning. Act directly.
-  - Do NOT create new test files, documentation, or reproduction scripts.
-
-  The repository is located at {workdir}.
+  The repository is at {workdir}. The MCP server instructions contain the
+  codebase overview and workflow guidance. Do not write standalone test scripts;
+  use the project's existing test suite.


### PR DESCRIPTION
## Summary

- **Replace verbose 20-line agent_prompt with a minimal 3-line prompt** in `mcpbr-config.yaml` to restore parallel tool calling in the Claude Code harness
- **Bump mcp-server version** from 0.9.2 to 0.9.4 in the recommended config
- **Track `mcpbr-config.yaml`** in git (un-ignore it) so the recommended config serves as documentation

## Problem

Verbose `agent_prompt` configurations with numbered workflow steps (e.g., "1. ORIENT... 2. LOCATE... 3. FIX...") suppress the Claude Code agent's natural parallel tool-calling behavior. Experiment data from 28+ mcpbr runs shows:

| Prompt style | Parallel tool call rate |
|---|---|
| No prompt or short (≤5 lines) | 0.9–25% |
| Long numbered steps (19-20 lines) | 0–0.4% |

## Solution

The MCP server's `instructions` field (in `src/server.ts`) already contains all workflow guidance: recommended workflow, parallel execution tips, anti-patterns, and tool reference. Duplicating this in the `agent_prompt` is both redundant and harmful.

The new minimal prompt is just 3 lines:

```yaml
agent_prompt: |
  {problem_statement}

  The repository is at {workdir}. The MCP server instructions contain the
  codebase overview and workflow guidance. Do not write standalone test scripts;
  use the project's existing test suite.
```

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (62/62 tests)
- [ ] Run mcpbr with the updated config on a small SWE-bench sample and verify parallel tool call rate is >5%
- [ ] Compare resolve rate against previous runs to confirm no regression

Ref #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated MCP server to version 0.9.4 with corresponding setup configuration
  * Streamlined agent configuration guidance for clearer implementation
  * Enhanced documentation with parallelism and setup recommendations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->