### PR TITLE
Add supermodeltools.com/trial CTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ npx @supermodeltools/mcp-server
 
 ## Configuration
 
-Get your API key from the [Supermodel Dashboard](https://dashboard.supermodeltools.com).
+Start your free trial at [supermodeltools.com/trial](https://supermodeltools.com/trial) to get an API key.
 
 | Variable | Description |
 |----------|-------------|

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ npx @supermodeltools/mcp-server
 
 ## Configuration
 
-Start your free trial at [supermodeltools.com/trial](https://supermodeltools.com/trial) to get an API key.
+**Save 40%+ on agent token costs — start free → [supermodeltools.com/trial](https://supermodeltools.com/trial)**
 
 | Variable | Description |
 |----------|-------------|


### PR DESCRIPTION
Adds the new `/trial` signup page link to the README so readers have a one-click path to start a free trial and get an API key.

Part of a coordinated set of PRs across the supermodeltools org adding `/trial` to each product's main user-facing surface.

Verified: https://supermodeltools.com/trial returns 200 (Pro $19/mo, Growth $199/mo, 14-day trial via Stripe).

Draft for review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Configuration section of the README: removed the previous dashboard link and now directs users to supermodeltools.com/trial to obtain an API key via a free-trial signup. The configuration variables table and other setup details remain unchanged, simplifying the initial API-key acquisition instructions for new users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->